### PR TITLE
fixed neuro->onli prefix

### DIFF
--- a/doc/content/specs/nidm-experiment_dev.html
+++ b/doc/content/specs/nidm-experiment_dev.html
@@ -511,124 +511,124 @@
             <section id="section-nidm:'Acquisition'">
                 <h1 label="Acquisition">nidm:'Acquisition'</h1>
                 <div class="glossary-ref">
-                    <a title="Acquisition"><dfn title="Acquisition">nidm:'Acquisition'</dfn></a>: An acquisition is an activty in which data about a subject is gathered.<p> <a title="Acquisition">nidm:'Acquisition'</a> is a prov:Activity and  has the following children: <a title="instrument-based-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#instrument-based-assessment">neuro:instrument-based-assessment</a>, <a title="variable-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#variable-assessment">neuro:variable-assessment</a>, <a title="Series">nidm:'Series'</a>.</p>
+                    <a title="Acquisition"><dfn title="Acquisition">nidm:'Acquisition'</dfn></a>: An acquisition is an activty in which data about a subject is gathered.<p> <a title="Acquisition">nidm:'Acquisition'</a> is a prov:Activity and  has the following children: <a title="Series">nidm:'Series'</a>, <a title="instrument-based-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#instrument-based-assessment">onli:instrument-based-assessment</a>, <a title="variable-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#variable-assessment">onli:variable-assessment</a>.</p>
                 </div>
-            <!-- neuro:instrument-based-assessment (instrument-based-assessment) -->
-            <section id="section-neuro:instrument-based-assessment">
-                <h1 label="instrument-based-assessment">neuro:instrument-based-assessment</h1>
-                <div class="glossary-ref">
-                    <a title="instrument-based-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#instrument-based-assessment"><dfn title="instrument-based-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#instrument-based-assessment">neuro:instrument-based-assessment</dfn></a>: An INSTRUMENT-BASED ASSESSMENT is a SUBJECT DATA ACQUISITION that captures some required information concerning the subject and involves the integration of data from instruments: TEST(-INSTRUMENTS) and/or QUESTIONNAIRES. When the purpose of the patient's examination is the assessment of her/his behavior, the examiner uses questionnaires rather than tests to rate the level of intensity/severity of a behavioral trait. Then, the appropriate action is a BEHAVIOURAL INTERVIEW rather than a BEHAVIOURAL TEST which is less adapted. 
-INSTRUMENT-BASED ASSESSMENTS are divided among TEST-BASED ASSESSMENTS and QUESTIONNAIRE-BASED ASSESSMENTS according to the kind of instrument which is administrated and therefore to the specific roles played by the subject and the healthcare professional in the assessment.<p> <a title="instrument-based-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#instrument-based-assessment">neuro:instrument-based-assessment</a> is a <a title="Acquisition">nidm:'Acquisition'</a> and  has the following children: <a title="questionnaire-based-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#questionnaire-based-assessment">neuro:questionnaire-based-assessment</a>, <a title="test-based-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#test-based-assessment">neuro:test-based-assessment</a>.</p>
-                </div>
-            <!-- neuro:questionnaire-based-assessment (questionnaire-based-assessment) -->
-            <section id="section-neuro:questionnaire-based-assessment">
-                <h1 label="questionnaire-based-assessment">neuro:questionnaire-based-assessment</h1>
-                <div class="glossary-ref">
-                    <a title="questionnaire-based-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#questionnaire-based-assessment"><dfn title="questionnaire-based-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#questionnaire-based-assessment">neuro:questionnaire-based-assessment</dfn></a>: A Questionnaire-based assessment is an Instrument-based assessment which involves the integration of data from questionnaires. A questionnaire-based assessment involves sets of questions (items), carried out in a structured way (known as structured interview) or semi-structured way, to provide normative data. Interview-based measures and rating scales are designed to be completed by clinicians, subjects, parents, caregivers. The scoring of each item contributes to the measure of the explored domain (e.g. Depression).
-“A directed conversation with the subject aimed at eliciting information   for psychiatric diagnosis, evaluation, treatment planning, etc.   The interview may be conducted by a social worker or psychologist.” (Source: MSH/MH). (Concept: [CUI C0021819] Interview, Psychological,   Semantic Type:  Diagnostic Procedure).
-QUESTIONNAIRE-BASED ASSESSMENTS are divided among PSYCHOLOGICAL INTERVIEWS, BEHAVIOURAL INTERVIEWS, and NEUROCLINICAL INTERVIEWS according to the kind of questionnaire that is used.<p> <a title="questionnaire-based-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#questionnaire-based-assessment">neuro:questionnaire-based-assessment</a> is a prov:Activity and  has the following children: <a title="behavioural-interview" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#behavioural-interview">neuro:behavioural-interview</a>, <a title="neuroclinical-interview" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#neuroclinical-interview">neuro:neuroclinical-interview</a>, <a title="psychological-interview" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#psychological-interview">neuro:psychological-interview</a>.</p>
-                </div>
-            <!-- neuro:behavioural-interview (behavioural-interview) -->
-            <section id="section-neuro:behavioural-interview">
-                <h1 label="behavioural-interview">neuro:behavioural-interview</h1>
-                <div class="glossary-ref">
-                    <a title="behavioural-interview" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#behavioural-interview"><dfn title="behavioural-interview" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#behavioural-interview">neuro:behavioural-interview</dfn></a>: A behavioural interview is a Questionnaire-based assessment carried out during a behavioral examination.<p> <a title="behavioural-interview" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#behavioural-interview">neuro:behavioural-interview</a> is a prov:Activity.</p>
-                </div>
-                </section>
-            <!-- neuro:neuroclinical-interview (neuroclinical-interview) -->
-            <section id="section-neuro:neuroclinical-interview">
-                <h1 label="neuroclinical-interview">neuro:neuroclinical-interview</h1>
-                <div class="glossary-ref">
-                    <a title="neuroclinical-interview" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#neuroclinical-interview"><dfn title="neuroclinical-interview" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#neuroclinical-interview">neuro:neuroclinical-interview</dfn></a>: A neuroclinical interview is a Questionnaire-based assessment carried out during a neurological examination.<p> <a title="neuroclinical-interview" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#neuroclinical-interview">neuro:neuroclinical-interview</a> is a prov:Activity.</p>
-                </div>
-                </section>
-            <!-- neuro:psychological-interview (psychological-interview) -->
-            <section id="section-neuro:psychological-interview">
-                <h1 label="psychological-interview">neuro:psychological-interview</h1>
-                <div class="glossary-ref">
-                    <a title="psychological-interview" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#psychological-interview"><dfn title="psychological-interview" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#psychological-interview">neuro:psychological-interview</dfn></a>: A psychological interview is a Questionnaire-based assessment carried out during a psychological examination.<p> <a title="psychological-interview" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#psychological-interview">neuro:psychological-interview</a> is a prov:Activity.</p>
-                </div>
-                </section>
-                </section>
-            <!-- neuro:test-based-assessment (test-based-assessment) -->
-            <section id="section-neuro:test-based-assessment">
-                <h1 label="test-based-assessment">neuro:test-based-assessment</h1>
-                <div class="glossary-ref">
-                    <a title="test-based-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#test-based-assessment"><dfn title="test-based-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#test-based-assessment">neuro:test-based-assessment</dfn></a>: A Test-based assessment is an Instrument-based assessment which involves the integration of data from tests. A Test-based assessment is conducted as a formal testing session to provide normative data.
-TEST-BASED ASSESSMENTS are divided among PSYCHOLOGICAL TESTS, BEHAVIOURAL TESTS and NEUROCLINICAL TESTS according to the kind of instrument that is used.<p> <a title="test-based-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#test-based-assessment">neuro:test-based-assessment</a> is a prov:Activity and  has the following children: <a title="behavioural-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#behavioural-test">neuro:behavioural-test</a>, <a title="neuroclinical-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#neuroclinical-test">neuro:neuroclinical-test</a>, <a title="psychological-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#psychological-test">neuro:psychological-test</a>.</p>
-                </div>
-            <!-- neuro:behavioural-test (behavioural-test) -->
-            <section id="section-neuro:behavioural-test">
-                <h1 label="behavioural-test">neuro:behavioural-test</h1>
-                <div class="glossary-ref">
-                    <a title="behavioural-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#behavioural-test"><dfn title="behavioural-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#behavioural-test">neuro:behavioural-test</dfn></a>: <p> <a title="behavioural-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#behavioural-test">neuro:behavioural-test</a> is a prov:Activity.</p>
-                </div>
-                </section>
-            <!-- neuro:neuroclinical-test (neuroclinical-test) -->
-            <section id="section-neuro:neuroclinical-test">
-                <h1 label="neuroclinical-test">neuro:neuroclinical-test</h1>
-                <div class="glossary-ref">
-                    <a title="neuroclinical-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#neuroclinical-test"><dfn title="neuroclinical-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#neuroclinical-test">neuro:neuroclinical-test</dfn></a>: “The Neuroclinical examination (Neurological test) is the usual clinical approach to the study of the brain functions. The Neurological test includes extensive study of the brain's chief product-behavior. [...] The neurologist examines the strength, efficiency, reactivity, and appropriateness of the patient's responses to commands, questions, discrete stimulation of particular neural subsystems, and challenges to specific muscle groups and motor patterns. […] In the neurological examination of behavior, the clinician reviews behavior patterns generated by neuroanatomical subsystems, measuring patients' responses in relatively coarse graduations or nothing their absence" (Lezak et al., 2004).<p> <a title="neuroclinical-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#neuroclinical-test">neuro:neuroclinical-test</a> is a prov:Activity.</p>
-                </div>
-                </section>
-            <!-- neuro:psychological-test (psychological-test) -->
-            <section id="section-neuro:psychological-test">
-                <h1 label="psychological-test">neuro:psychological-test</h1>
-                <div class="glossary-ref">
-                    <a title="psychological-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#psychological-test"><dfn title="psychological-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#psychological-test">neuro:psychological-test</dfn></a>: "[…] psychological assessment […] involves the intensive study of behavior by means of interviews and standardized scaled tests and questionnaires that provide relatively precise and sensitive indices of behaviour." (Lezak et al., 2004).
-PSYCHOLOGICAL TESTS are divided among NEUROPSYCHOLOGICAL TESTS and EXPERIMENTAL PSYCHOLOGY TESTS according to the kind of instrument that is used.<p> <a title="psychological-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#psychological-test">neuro:psychological-test</a> is a prov:Activity and  has the following children: <a title="experimental-psychology-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#experimental-psychology-test">neuro:experimental-psychology-test</a>, <a title="neuropsychological-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#neuropsychological-test">neuro:neuropsychological-test</a>.</p>
-                </div>
-            <!-- neuro:experimental-psychology-test (experimental-psychology-test) -->
-            <section id="section-neuro:experimental-psychology-test">
-                <h1 label="experimental-psychology-test">neuro:experimental-psychology-test</h1>
-                <div class="glossary-ref">
-                    <a title="experimental-psychology-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#experimental-psychology-test"><dfn title="experimental-psychology-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#experimental-psychology-test">neuro:experimental-psychology-test</dfn></a>: <p> <a title="experimental-psychology-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#experimental-psychology-test">neuro:experimental-psychology-test</a> is and  has the following child: <a title="psychophysical-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#psychophysical-test">neuro:psychophysical-test</a>.</p>
-                </div>
-            <!-- neuro:psychophysical-test (psychophysical-test) -->
-            <section id="section-neuro:psychophysical-test">
-                <h1 label="psychophysical-test">neuro:psychophysical-test</h1>
-                <div class="glossary-ref">
-                    <a title="psychophysical-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#psychophysical-test"><dfn title="psychophysical-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#psychophysical-test">neuro:psychophysical-test</dfn></a>: <p> <a title="psychophysical-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#psychophysical-test">neuro:psychophysical-test</a> is.</p>
-                </div>
-                </section>
-                </section>
-            <!-- neuro:neuropsychological-test (neuropsychological-test) -->
-            <section id="section-neuro:neuropsychological-test">
-                <h1 label="neuropsychological-test">neuro:neuropsychological-test</h1>
-                <div class="glossary-ref">
-                    <a title="neuropsychological-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#neuropsychological-test"><dfn title="neuropsychological-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#neuropsychological-test">neuro:neuropsychological-test</dfn></a>: "Neuropsychological assessment is a method of examining the brain by studying its behavioural product. Since the subject matter of neuropsychological assessment is behavior, it relies on many of the same techniques, assumptions, and theories as does psychological assessment. The distinctive character of neuropsychological assessment lies in a conceptual frame of reference that takes brain function as its point of departure. Regardless of whether a behavioral study is undertaken for clinical or research purposes, it is neuropsychological so long as the questions that prompted it, the central issues, the findings, or the inferences drawn from them ultimately relate to brain function" (Lezak et al., 2004).<p> <a title="neuropsychological-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#neuropsychological-test">neuro:neuropsychological-test</a> is.</p>
-                </div>
-                </section>
-                </section>
-                </section>
-                </section>
-            <!-- neuro:variable-assessment (variable-assessment) -->
-            <section id="section-neuro:variable-assessment">
-                <h1 label="variable-assessment">neuro:variable-assessment</h1>
-                <div class="glossary-ref">
-                    <a title="variable-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#variable-assessment"><dfn title="variable-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#variable-assessment">neuro:variable-assessment</dfn></a>: A variable assessment is an activity that results in a value assigned to a specific item on an assessment instrument question or test.<p> <a title="variable-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#variable-assessment">neuro:variable-assessment</a> is a <a title="Acquisition">nidm:'Acquisition'</a> and  has the following children: <a title="coded-variable-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#coded-variable-assessment">neuro:coded-variable-assessment</a>, <a title="numerical-variable-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#numerical-variable-assessment">neuro:numerical-variable-assessment</a>.</p>
-                </div>
-            <!-- neuro:coded-variable-assessment (coded-variable-assessment) -->
-            <section id="section-neuro:coded-variable-assessment">
-                <h1 label="coded-variable-assessment">neuro:coded-variable-assessment</h1>
-                <div class="glossary-ref">
-                    <a title="coded-variable-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#coded-variable-assessment"><dfn title="coded-variable-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#coded-variable-assessment">neuro:coded-variable-assessment</dfn></a>: <p> <a title="coded-variable-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#coded-variable-assessment">neuro:coded-variable-assessment</a> is a prov:Activity.</p>
-                </div>
-                </section>
-            <!-- neuro:numerical-variable-assessment (numerical-variable-assessment) -->
-            <section id="section-neuro:numerical-variable-assessment">
-                <h1 label="numerical-variable-assessment">neuro:numerical-variable-assessment</h1>
-                <div class="glossary-ref">
-                    <a title="numerical-variable-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#numerical-variable-assessment"><dfn title="numerical-variable-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#numerical-variable-assessment">neuro:numerical-variable-assessment</dfn></a>: <p> <a title="numerical-variable-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#numerical-variable-assessment">neuro:numerical-variable-assessment</a> is a prov:Activity.</p>
-                </div>
-                </section>
-                </section>
             <!-- nidm:'Series' (Series) -->
             <section id="section-nidm:'Series'">
                 <h1 label="Series">nidm:'Series'</h1>
                 <div class="glossary-ref">
                     <a title="Series"><dfn title="Series">nidm:'Series'</dfn></a>: A series is an activity in which data of a single type is acquired such that one acquisition takes place during the same temporal epoch.<p> <a title="Series">nidm:'Series'</a> is a <a title="Acquisition">nidm:'Acquisition'</a>.</p>
                 </div>
+                </section>
+            <!-- onli:instrument-based-assessment (instrument-based-assessment) -->
+            <section id="section-onli:instrument-based-assessment">
+                <h1 label="instrument-based-assessment">onli:instrument-based-assessment</h1>
+                <div class="glossary-ref">
+                    <a title="instrument-based-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#instrument-based-assessment"><dfn title="instrument-based-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#instrument-based-assessment">onli:instrument-based-assessment</dfn></a>: An INSTRUMENT-BASED ASSESSMENT is a SUBJECT DATA ACQUISITION that captures some required information concerning the subject and involves the integration of data from instruments: TEST(-INSTRUMENTS) and/or QUESTIONNAIRES. When the purpose of the patient's examination is the assessment of her/his behavior, the examiner uses questionnaires rather than tests to rate the level of intensity/severity of a behavioral trait. Then, the appropriate action is a BEHAVIOURAL INTERVIEW rather than a BEHAVIOURAL TEST which is less adapted. 
+INSTRUMENT-BASED ASSESSMENTS are divided among TEST-BASED ASSESSMENTS and QUESTIONNAIRE-BASED ASSESSMENTS according to the kind of instrument which is administrated and therefore to the specific roles played by the subject and the healthcare professional in the assessment.<p> <a title="instrument-based-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#instrument-based-assessment">onli:instrument-based-assessment</a> is a <a title="Acquisition">nidm:'Acquisition'</a> and  has the following children: <a title="questionnaire-based-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#questionnaire-based-assessment">onli:questionnaire-based-assessment</a>, <a title="test-based-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#test-based-assessment">onli:test-based-assessment</a>.</p>
+                </div>
+            <!-- onli:questionnaire-based-assessment (questionnaire-based-assessment) -->
+            <section id="section-onli:questionnaire-based-assessment">
+                <h1 label="questionnaire-based-assessment">onli:questionnaire-based-assessment</h1>
+                <div class="glossary-ref">
+                    <a title="questionnaire-based-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#questionnaire-based-assessment"><dfn title="questionnaire-based-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#questionnaire-based-assessment">onli:questionnaire-based-assessment</dfn></a>: A Questionnaire-based assessment is an Instrument-based assessment which involves the integration of data from questionnaires. A questionnaire-based assessment involves sets of questions (items), carried out in a structured way (known as structured interview) or semi-structured way, to provide normative data. Interview-based measures and rating scales are designed to be completed by clinicians, subjects, parents, caregivers. The scoring of each item contributes to the measure of the explored domain (e.g. Depression).
+“A directed conversation with the subject aimed at eliciting information   for psychiatric diagnosis, evaluation, treatment planning, etc.   The interview may be conducted by a social worker or psychologist.” (Source: MSH/MH). (Concept: [CUI C0021819] Interview, Psychological,   Semantic Type:  Diagnostic Procedure).
+QUESTIONNAIRE-BASED ASSESSMENTS are divided among PSYCHOLOGICAL INTERVIEWS, BEHAVIOURAL INTERVIEWS, and NEUROCLINICAL INTERVIEWS according to the kind of questionnaire that is used.<p> <a title="questionnaire-based-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#questionnaire-based-assessment">onli:questionnaire-based-assessment</a> is a prov:Activity and  has the following children: <a title="behavioural-interview" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#behavioural-interview">onli:behavioural-interview</a>, <a title="neuroclinical-interview" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#neuroclinical-interview">onli:neuroclinical-interview</a>, <a title="psychological-interview" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#psychological-interview">onli:psychological-interview</a>.</p>
+                </div>
+            <!-- onli:behavioural-interview (behavioural-interview) -->
+            <section id="section-onli:behavioural-interview">
+                <h1 label="behavioural-interview">onli:behavioural-interview</h1>
+                <div class="glossary-ref">
+                    <a title="behavioural-interview" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#behavioural-interview"><dfn title="behavioural-interview" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#behavioural-interview">onli:behavioural-interview</dfn></a>: A behavioural interview is a Questionnaire-based assessment carried out during a behavioral examination.<p> <a title="behavioural-interview" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#behavioural-interview">onli:behavioural-interview</a> is a prov:Activity.</p>
+                </div>
+                </section>
+            <!-- onli:neuroclinical-interview (neuroclinical-interview) -->
+            <section id="section-onli:neuroclinical-interview">
+                <h1 label="neuroclinical-interview">onli:neuroclinical-interview</h1>
+                <div class="glossary-ref">
+                    <a title="neuroclinical-interview" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#neuroclinical-interview"><dfn title="neuroclinical-interview" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#neuroclinical-interview">onli:neuroclinical-interview</dfn></a>: A neuroclinical interview is a Questionnaire-based assessment carried out during a neurological examination.<p> <a title="neuroclinical-interview" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#neuroclinical-interview">onli:neuroclinical-interview</a> is a prov:Activity.</p>
+                </div>
+                </section>
+            <!-- onli:psychological-interview (psychological-interview) -->
+            <section id="section-onli:psychological-interview">
+                <h1 label="psychological-interview">onli:psychological-interview</h1>
+                <div class="glossary-ref">
+                    <a title="psychological-interview" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#psychological-interview"><dfn title="psychological-interview" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#psychological-interview">onli:psychological-interview</dfn></a>: A psychological interview is a Questionnaire-based assessment carried out during a psychological examination.<p> <a title="psychological-interview" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#psychological-interview">onli:psychological-interview</a> is a prov:Activity.</p>
+                </div>
+                </section>
+                </section>
+            <!-- onli:test-based-assessment (test-based-assessment) -->
+            <section id="section-onli:test-based-assessment">
+                <h1 label="test-based-assessment">onli:test-based-assessment</h1>
+                <div class="glossary-ref">
+                    <a title="test-based-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#test-based-assessment"><dfn title="test-based-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#test-based-assessment">onli:test-based-assessment</dfn></a>: A Test-based assessment is an Instrument-based assessment which involves the integration of data from tests. A Test-based assessment is conducted as a formal testing session to provide normative data.
+TEST-BASED ASSESSMENTS are divided among PSYCHOLOGICAL TESTS, BEHAVIOURAL TESTS and NEUROCLINICAL TESTS according to the kind of instrument that is used.<p> <a title="test-based-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#test-based-assessment">onli:test-based-assessment</a> is a prov:Activity and  has the following children: <a title="behavioural-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#behavioural-test">onli:behavioural-test</a>, <a title="neuroclinical-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#neuroclinical-test">onli:neuroclinical-test</a>, <a title="psychological-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#psychological-test">onli:psychological-test</a>.</p>
+                </div>
+            <!-- onli:behavioural-test (behavioural-test) -->
+            <section id="section-onli:behavioural-test">
+                <h1 label="behavioural-test">onli:behavioural-test</h1>
+                <div class="glossary-ref">
+                    <a title="behavioural-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#behavioural-test"><dfn title="behavioural-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#behavioural-test">onli:behavioural-test</dfn></a>: <p> <a title="behavioural-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#behavioural-test">onli:behavioural-test</a> is a prov:Activity.</p>
+                </div>
+                </section>
+            <!-- onli:neuroclinical-test (neuroclinical-test) -->
+            <section id="section-onli:neuroclinical-test">
+                <h1 label="neuroclinical-test">onli:neuroclinical-test</h1>
+                <div class="glossary-ref">
+                    <a title="neuroclinical-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#neuroclinical-test"><dfn title="neuroclinical-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#neuroclinical-test">onli:neuroclinical-test</dfn></a>: “The Neuroclinical examination (Neurological test) is the usual clinical approach to the study of the brain functions. The Neurological test includes extensive study of the brain's chief product-behavior. [...] The neurologist examines the strength, efficiency, reactivity, and appropriateness of the patient's responses to commands, questions, discrete stimulation of particular neural subsystems, and challenges to specific muscle groups and motor patterns. […] In the neurological examination of behavior, the clinician reviews behavior patterns generated by neuroanatomical subsystems, measuring patients' responses in relatively coarse graduations or nothing their absence" (Lezak et al., 2004).<p> <a title="neuroclinical-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#neuroclinical-test">onli:neuroclinical-test</a> is a prov:Activity.</p>
+                </div>
+                </section>
+            <!-- onli:psychological-test (psychological-test) -->
+            <section id="section-onli:psychological-test">
+                <h1 label="psychological-test">onli:psychological-test</h1>
+                <div class="glossary-ref">
+                    <a title="psychological-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#psychological-test"><dfn title="psychological-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#psychological-test">onli:psychological-test</dfn></a>: "[…] psychological assessment […] involves the intensive study of behavior by means of interviews and standardized scaled tests and questionnaires that provide relatively precise and sensitive indices of behaviour." (Lezak et al., 2004).
+PSYCHOLOGICAL TESTS are divided among NEUROPSYCHOLOGICAL TESTS and EXPERIMENTAL PSYCHOLOGY TESTS according to the kind of instrument that is used.<p> <a title="psychological-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#psychological-test">onli:psychological-test</a> is a prov:Activity and  has the following children: <a title="experimental-psychology-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#experimental-psychology-test">onli:experimental-psychology-test</a>, <a title="neuropsychological-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#neuropsychological-test">onli:neuropsychological-test</a>.</p>
+                </div>
+            <!-- onli:experimental-psychology-test (experimental-psychology-test) -->
+            <section id="section-onli:experimental-psychology-test">
+                <h1 label="experimental-psychology-test">onli:experimental-psychology-test</h1>
+                <div class="glossary-ref">
+                    <a title="experimental-psychology-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#experimental-psychology-test"><dfn title="experimental-psychology-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#experimental-psychology-test">onli:experimental-psychology-test</dfn></a>: <p> <a title="experimental-psychology-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#experimental-psychology-test">onli:experimental-psychology-test</a> is and  has the following child: <a title="psychophysical-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#psychophysical-test">onli:psychophysical-test</a>.</p>
+                </div>
+            <!-- onli:psychophysical-test (psychophysical-test) -->
+            <section id="section-onli:psychophysical-test">
+                <h1 label="psychophysical-test">onli:psychophysical-test</h1>
+                <div class="glossary-ref">
+                    <a title="psychophysical-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#psychophysical-test"><dfn title="psychophysical-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#psychophysical-test">onli:psychophysical-test</dfn></a>: <p> <a title="psychophysical-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#psychophysical-test">onli:psychophysical-test</a> is.</p>
+                </div>
+                </section>
+                </section>
+            <!-- onli:neuropsychological-test (neuropsychological-test) -->
+            <section id="section-onli:neuropsychological-test">
+                <h1 label="neuropsychological-test">onli:neuropsychological-test</h1>
+                <div class="glossary-ref">
+                    <a title="neuropsychological-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#neuropsychological-test"><dfn title="neuropsychological-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#neuropsychological-test">onli:neuropsychological-test</dfn></a>: "Neuropsychological assessment is a method of examining the brain by studying its behavioural product. Since the subject matter of neuropsychological assessment is behavior, it relies on many of the same techniques, assumptions, and theories as does psychological assessment. The distinctive character of neuropsychological assessment lies in a conceptual frame of reference that takes brain function as its point of departure. Regardless of whether a behavioral study is undertaken for clinical or research purposes, it is neuropsychological so long as the questions that prompted it, the central issues, the findings, or the inferences drawn from them ultimately relate to brain function" (Lezak et al., 2004).<p> <a title="neuropsychological-test" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#neuropsychological-test">onli:neuropsychological-test</a> is.</p>
+                </div>
+                </section>
+                </section>
+                </section>
+                </section>
+            <!-- onli:variable-assessment (variable-assessment) -->
+            <section id="section-onli:variable-assessment">
+                <h1 label="variable-assessment">onli:variable-assessment</h1>
+                <div class="glossary-ref">
+                    <a title="variable-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#variable-assessment"><dfn title="variable-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#variable-assessment">onli:variable-assessment</dfn></a>: A variable assessment is an activity that results in a value assigned to a specific item on an assessment instrument question or test.<p> <a title="variable-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#variable-assessment">onli:variable-assessment</a> is a <a title="Acquisition">nidm:'Acquisition'</a> and  has the following children: <a title="coded-variable-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#coded-variable-assessment">onli:coded-variable-assessment</a>, <a title="numerical-variable-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#numerical-variable-assessment">onli:numerical-variable-assessment</a>.</p>
+                </div>
+            <!-- onli:coded-variable-assessment (coded-variable-assessment) -->
+            <section id="section-onli:coded-variable-assessment">
+                <h1 label="coded-variable-assessment">onli:coded-variable-assessment</h1>
+                <div class="glossary-ref">
+                    <a title="coded-variable-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#coded-variable-assessment"><dfn title="coded-variable-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#coded-variable-assessment">onli:coded-variable-assessment</dfn></a>: <p> <a title="coded-variable-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#coded-variable-assessment">onli:coded-variable-assessment</a> is a prov:Activity.</p>
+                </div>
+                </section>
+            <!-- onli:numerical-variable-assessment (numerical-variable-assessment) -->
+            <section id="section-onli:numerical-variable-assessment">
+                <h1 label="numerical-variable-assessment">onli:numerical-variable-assessment</h1>
+                <div class="glossary-ref">
+                    <a title="numerical-variable-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#numerical-variable-assessment"><dfn title="numerical-variable-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#numerical-variable-assessment">onli:numerical-variable-assessment</dfn></a>: <p> <a title="numerical-variable-assessment" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#numerical-variable-assessment">onli:numerical-variable-assessment</a> is a prov:Activity.</p>
+                </div>
+                </section>
                 </section>
                 </section>
             <!-- nidm:'Image Data Reconstruction' (ImageDataReconstruction) -->
@@ -670,7 +670,7 @@ PSYCHOLOGICAL TESTS are divided among NEUROPSYCHOLOGICAL TESTS and EXPERIMENTAL 
             <section id="section-nidm:'Acquisition Object'">
                 <h1 label="AcquisitionObject">nidm:'Acquisition Object'</h1>
                 <div class="glossary-ref">
-                    <a title="AcquisitionObject"><dfn title="AcquisitionObject">nidm:'Acquisition Object'</dfn></a>: An acquisition object is an entity that is gathered from a subject during an acquisition activity.<p> <a title="AcquisitionObject">nidm:'Acquisition Object'</a> is a prov:'Entity' and  has the following children: <a title="assessment-instrument" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#assessment-instrument">neuro:assessment-instrument</a>, <a title="instrument-variable" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#instrument-variable">neuro:instrument-variable</a>, <a title="ProcessedAcquisitionObject">nidm:'Processed Acquisition Object'</a>, <a title="RawAcquisitionObject">nidm:'Raw Acquisition Object'</a>, <a title="ReconstructedAcquisitionObject">nidm:'Reconstructed Acquisition Object'</a>.</p>
+                    <a title="AcquisitionObject"><dfn title="AcquisitionObject">nidm:'Acquisition Object'</dfn></a>: An acquisition object is an entity that is gathered from a subject during an acquisition activity.<p> <a title="AcquisitionObject">nidm:'Acquisition Object'</a> is a prov:'Entity' and  has the following children: <a title="ProcessedAcquisitionObject">nidm:'Processed Acquisition Object'</a>, <a title="RawAcquisitionObject">nidm:'Raw Acquisition Object'</a>, <a title="ReconstructedAcquisitionObject">nidm:'Reconstructed Acquisition Object'</a>, <a title="assessment-instrument" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#assessment-instrument">onli:assessment-instrument</a>, <a title="instrument-variable" href ="http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#instrument-variable">onli:instrument-variable</a>.</p>
                 </div>
                 </section>
             <!-- nidm:'Acquisition Object Quality' (AcquisitionObjectQuality) -->

--- a/scripts/owl_to_webpage.py
+++ b/scripts/owl_to_webpage.py
@@ -20,7 +20,7 @@ class OwlSpecification(object):
         self.owl = OwlReader(owl_file, import_files)
         self.owl.graph.bind('nidm', 'http://purl.org/nidash/nidm#')
         self.owl.graph.bind('sio', 'http://semanticscience.org/resource/')
-        self.owl.graph.bind('neuro', 'http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#')
+        self.owl.graph.bind('onli', 'http://neurolog.unice.fr/ontoneurolog/v3.0/instrument.owl#')
         self.name = spec_name
         self.component = self.name.lower().replace("-", "_")
         self.section_open = 0


### PR DESCRIPTION
Code was writing the prefix of "neuro:" for all of the ontoneurolog-instruments term.  This was assigned in `.../scripts/owl_to_webpage.py`. Changed this to "onli" which is being used in the nidm-experiment.owl file and in PyNIDM.