### PR TITLE
Added empty line to retrigger tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,4 @@ We meet every week by videoconference on Mondays at 8-9am PDT / 11am-12pm EDT / 
 
 ## Acknowledgements
 The NIDM working group is a collaboration supported by the [INCF](http://www.incf.org).
+


### PR DESCRIPTION
This a companion PR to https://github.com/incf-nidash/nidmresults/pull/59. To retrigger the tests and check that removing the cast as suggested by @khelm does not cause backward compatibility issues.