### PR TITLE
comment out context file use in refresh.py

### DIFF
--- a/doc/content/specs/nidm_html/dicom.html
+++ b/doc/content/specs/nidm_html/dicom.html
@@ -1794,7 +1794,7 @@
             <section id="dicom_00089215">
                 <h2 label="dicom_00089215">dicom:'Derivation Code Sequence'</h2>
                 <div class="glossary-ref">
-                    <a title="dicom_00089215" href ="#dicom_00089215"><dfn title="dicom_00089215" href ="#dicom_00089215">dicom:'Derivation Code Sequence'</dfn></a>: A coded description of how this ROI was derived.<p><a title="dicom_00089215" href ="#dicom_00089215">dicom:'Derivation Code Sequence'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
+                    <a title="dicom_00089215" href ="#dicom_00089215"><dfn title="dicom_00089215" href ="#dicom_00089215">dicom:'Derivation Code Sequence'</dfn></a>: A coded description of how this dose was derived from other RT Dose and/or RT Plan objects.<p><a title="dicom_00089215" href ="#dicom_00089215">dicom:'Derivation Code Sequence'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
                 </div>
             </section>
             <!-- dicom:'Referenced Presentation State Sequence' (dicom_00089237) -->
@@ -2347,7 +2347,7 @@
             <section id="dicom_00120081">
                 <h2 label="dicom_00120081">dicom:'Clinical Trial Protocol Ethics Committee Name'</h2>
                 <div class="glossary-ref">
-                    <a title="dicom_00120081" href ="#dicom_00120081"><dfn title="dicom_00120081" href ="#dicom_00120081">dicom:'Clinical Trial Protocol Ethics Committee Name'</dfn></a>: Name of the Ethics Committee or Institutional Review Board (IRB) responsible for approval of the Clinical Trial.<p><a title="dicom_00120081" href ="#dicom_00120081">dicom:'Clinical Trial Protocol Ethics Committee Name'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
+                    <a title="dicom_00120081" href ="#dicom_00120081"><dfn title="dicom_00120081" href ="#dicom_00120081">dicom:'Clinical Trial Protocol Ethics Committee Name'</dfn></a>: Name of the Ethics Committee or Institutional Review Board (IRB) or Institutional Animal Care and Use Committees (IACUC) responsible for approval of the Clinical Trial or research.<p><a title="dicom_00120081" href ="#dicom_00120081">dicom:'Clinical Trial Protocol Ethics Committee Name'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
                 </div>
             </section>
             <!-- dicom:'Clinical Trial Protocol Ethics Committee Approval Number' (dicom_00120082) -->
@@ -2963,7 +2963,7 @@
             <section id="dicom_00181063">
                 <h2 label="dicom_00181063">dicom:'Frame Time'</h2>
                 <div class="glossary-ref">
-                    <a title="dicom_00181063" href ="#dicom_00181063"><dfn title="dicom_00181063" href ="#dicom_00181063">dicom:'Frame Time'</dfn></a>: Nominal time per individual frame in msec.<p><a title="dicom_00181063" href ="#dicom_00181063">dicom:'Frame Time'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
+                    <a title="dicom_00181063" href ="#dicom_00181063"><dfn title="dicom_00181063" href ="#dicom_00181063">dicom:'Frame Time'</dfn></a>: Nominal duration per individual frame, in msec.<p><a title="dicom_00181063" href ="#dicom_00181063">dicom:'Frame Time'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
                 </div>
             </section>
             <!-- dicom:'Cardiac Framing Type' (dicom_00181064) -->
@@ -3103,7 +3103,7 @@
             <section id="dicom_00181081">
                 <h2 label="dicom_00181081">dicom:'Low R-R Value'</h2>
                 <div class="glossary-ref">
-                    <a title="dicom_00181081" href ="#dicom_00181081"><dfn title="dicom_00181081" href ="#dicom_00181081">dicom:'Low R-R Value'</dfn></a>: R-R interval low limit for beat rejection, in ms.<p><a title="dicom_00181081" href ="#dicom_00181081">dicom:'Low R-R Value'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
+                    <a title="dicom_00181081" href ="#dicom_00181081"><dfn title="dicom_00181081" href ="#dicom_00181081">dicom:'Low R-R Value'</dfn></a>: R-R interval low limit for beat rejection, in ms. Required if Cardiac Synchronization Technique (0018,9037) equals PROSPECTIVE or RETROSPECTIVE.<p><a title="dicom_00181081" href ="#dicom_00181081">dicom:'Low R-R Value'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
                 </div>
             </section>
             <!-- dicom:'High R-R Value' (dicom_00181082) -->
@@ -3761,7 +3761,7 @@
             <section id="dicom_00181508">
                 <h2 label="dicom_00181508">dicom:'Positioner Type'</h2>
                 <div class="glossary-ref">
-                    <a title="dicom_00181508" href ="#dicom_00181508"><dfn title="dicom_00181508" href ="#dicom_00181508">dicom:'Positioner Type'</dfn></a>: Defined Terms: CARM COLUMN MAMMOGRAPHIC PANORAMIC CEPHALOSTAT RIGID NONE The term CARM can apply to any positioner with 2 degrees of freedom of rotation of the X-Ray beam about the Imaging Subject. The term COLUMN can apply to any positioner with 1 degree of freedom of rotation of the X-Ray beam about the Imaging Subject.<p><a title="dicom_00181508" href ="#dicom_00181508">dicom:'Positioner Type'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
+                    <a title="dicom_00181508" href ="#dicom_00181508"><dfn title="dicom_00181508" href ="#dicom_00181508">dicom:'Positioner Type'</dfn></a>: Defined Terms: CARM COLUMN The term CARM can apply to any positioner with 2 degrees of freedom of rotation of the X-Ray beam about the Imaging Subject. The term COLUMN can apply to any positioner with 1 degree of freedom of rotation of the X-Ray beam about the Imaging Subject.<p><a title="dicom_00181508" href ="#dicom_00181508">dicom:'Positioner Type'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
                 </div>
             </section>
             <!-- dicom:'Positioner Primary Angle' (dicom_00181510) -->
@@ -3894,7 +3894,7 @@
             <section id="dicom_00181702">
                 <h2 label="dicom_00181702">dicom:'Collimator Left Vertical Edge'</h2>
                 <div class="glossary-ref">
-                    <a title="dicom_00181702" href ="#dicom_00181702"><dfn title="dicom_00181702" href ="#dicom_00181702">dicom:'Collimator Left Vertical Edge'</dfn></a>: Required if a value of Collimator Shape (0018,1700) is RECTANGULAR. Location of the left edge of the rectangular collimator with respect to pixels in the image given as column.<p><a title="dicom_00181702" href ="#dicom_00181702">dicom:'Collimator Left Vertical Edge'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
+                    <a title="dicom_00181702" href ="#dicom_00181702"><dfn title="dicom_00181702" href ="#dicom_00181702">dicom:'Collimator Left Vertical Edge'</dfn></a>: Required if Collimator Shape (0018,1700) is RECTANGULAR. Location of the left edge of the rectangular collimator expressed as effective pixel column.<p><a title="dicom_00181702" href ="#dicom_00181702">dicom:'Collimator Left Vertical Edge'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
                 </div>
             </section>
             <!-- dicom:'Collimator Right Vertical Edge' (dicom_00181704) -->
@@ -4097,7 +4097,7 @@
             <section id="dicom_00183103">
                 <h2 label="dicom_00183103">dicom:'IVUS Pullback Start Frame Number'</h2>
                 <div class="glossary-ref">
-                    <a title="dicom_00183103" href ="#dicom_00183103"><dfn title="dicom_00183103" href ="#dicom_00183103">dicom:'IVUS Pullback Start Frame Number'</dfn></a>: Required if IVUS Acquisition (0018,3100) value is MOTOR<em>PULLBACK or GATED</em>PULLBACK.<p><a title="dicom_00183103" href ="#dicom_00183103">dicom:'IVUS Pullback Start Frame Number'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
+                    <a title="dicom_00183103" href ="#dicom_00183103"><dfn title="dicom_00183103" href ="#dicom_00183103">dicom:'IVUS Pullback Start Frame Number'</dfn></a>: Frame number at which the motorized portion of the acquisition begins.<p><a title="dicom_00183103" href ="#dicom_00183103">dicom:'IVUS Pullback Start Frame Number'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
                 </div>
             </section>
             <!-- dicom:'IVUS Pullback Stop Frame Number' (dicom_00183104) -->
@@ -6078,7 +6078,7 @@
             <section id="dicom_00189325">
                 <h2 label="dicom_00189325">dicom:'CT X-Ray Details Sequence'</h2>
                 <div class="glossary-ref">
-                    <a title="dicom_00189325" href ="#dicom_00189325"><dfn title="dicom_00189325" href ="#dicom_00189325">dicom:'CT X-Ray Details Sequence'</dfn></a>: Contains the attributes defining the x-ray information.<p><a title="dicom_00189325" href ="#dicom_00189325">dicom:'CT X-Ray Details Sequence'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
+                    <a title="dicom_00189325" href ="#dicom_00189325"><dfn title="dicom_00189325" href ="#dicom_00189325">dicom:'CT X-Ray Details Sequence'</dfn></a>: Parameter values for each of the X-Ray beams in the Acquisition Protocol Element. Each item in the sequence describes one X-Ray beam.<p><a title="dicom_00189325" href ="#dicom_00189325">dicom:'CT X-Ray Details Sequence'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
                 </div>
             </section>
             <!-- dicom:'CT Position Sequence' (dicom_00189326) -->
@@ -6113,7 +6113,7 @@
             <section id="dicom_00189330">
                 <h2 label="dicom_00189330">dicom:'X-Ray Tube Current in mA'</h2>
                 <div class="glossary-ref">
-                    <a title="dicom_00189330" href ="#dicom_00189330"><dfn title="dicom_00189330" href ="#dicom_00189330">dicom:'X-Ray Tube Current in mA'</dfn></a>: Average of the nominal X-Ray tube currents in milliamperes for all frames.<p><a title="dicom_00189330" href ="#dicom_00189330">dicom:'X-Ray Tube Current in mA'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
+                    <a title="dicom_00189330" href ="#dicom_00189330"><dfn title="dicom_00189330" href ="#dicom_00189330">dicom:'X-Ray Tube Current in mA'</dfn></a>: Average (or exact, depending upon context) of the nominal X-Ray tube currents in milliamperes for all frames. Required if present and consistent in the contributing SOP Instances. Required if Modality (0008,0060) is MG.<p><a title="dicom_00189330" href ="#dicom_00189330">dicom:'X-Ray Tube Current in mA'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
                 </div>
             </section>
             <!-- dicom:'Exposure in mAs' (dicom_00189332) -->
@@ -7765,7 +7765,7 @@
             <section id="dicom_0020000d">
                 <h2 label="dicom_0020000D">dicom:'Study Instance UID'</h2>
                 <div class="glossary-ref">
-                    <a title="dicom_0020000D" href ="#dicom_0020000d"><dfn title="dicom_0020000D" href ="#dicom_0020000d">dicom:'Study Instance UID'</dfn></a>: The unique identifier for the Study provided for this Requested Procedure.<p><a title="dicom_0020000D" href ="#dicom_0020000d">dicom:'Study Instance UID'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
+                    <a title="dicom_0020000D" href ="#dicom_0020000d"><dfn title="dicom_0020000D" href ="#dicom_0020000d">dicom:'Study Instance UID'</dfn></a>: Unique identifier for the Study.<p><a title="dicom_0020000D" href ="#dicom_0020000d">dicom:'Study Instance UID'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
                 </div>
             </section>
             <!-- dicom:'Series Instance UID' (dicom_0020000E) -->
@@ -8031,7 +8031,7 @@
             <section id="dicom_00209164">
                 <h2 label="dicom_00209164">dicom:'Dimension Organization UID'</h2>
                 <div class="glossary-ref">
-                    <a title="dicom_00209164" href ="#dicom_00209164"><dfn title="dicom_00209164" href ="#dicom_00209164">dicom:'Dimension Organization UID'</dfn></a>: Uniquely identifies a set of dimensions referenced within the containing SOP Instance.<p><a title="dicom_00209164" href ="#dicom_00209164">dicom:'Dimension Organization UID'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
+                    <a title="dicom_00209164" href ="#dicom_00209164"><dfn title="dicom_00209164" href ="#dicom_00209164">dicom:'Dimension Organization UID'</dfn></a>: Uniquely identifies a set of dimensions referenced within the containing SOP Instance. In particular the dimension described by this sequence item is associated with this Dimension Organization UID.<p><a title="dicom_00209164" href ="#dicom_00209164">dicom:'Dimension Organization UID'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
                 </div>
             </section>
             <!-- dicom:'Dimension Index Pointer' (dicom_00209165) -->
@@ -8283,7 +8283,7 @@
             <section id="dicom_00220001">
                 <h2 label="dicom_00220001">dicom:'Light Path Filter Pass-Through Wavelength'</h2>
                 <div class="glossary-ref">
-                    <a title="dicom_00220001" href ="#dicom_00220001"><dfn title="dicom_00220001" href ="#dicom_00220001">dicom:'Light Path Filter Pass-Through Wavelength'</dfn></a>: Nominal pass-through wavelength of light path filter in nm.<p><a title="dicom_00220001" href ="#dicom_00220001">dicom:'Light Path Filter Pass-Through Wavelength'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
+                    <a title="dicom_00220001" href ="#dicom_00220001"><dfn title="dicom_00220001" href ="#dicom_00220001">dicom:'Light Path Filter Pass-Through Wavelength'</dfn></a>: Nominal pass-through wavelength of light path filter(s) in nm.<p><a title="dicom_00220001" href ="#dicom_00220001">dicom:'Light Path Filter Pass-Through Wavelength'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
                 </div>
             </section>
             <!-- dicom:'Light Path Filter Pass Band' (dicom_00220002) -->
@@ -9977,7 +9977,7 @@
             <section id="dicom_00280009">
                 <h2 label="dicom_00280009">dicom:'Frame Increment Pointer'</h2>
                 <div class="glossary-ref">
-                    <a title="dicom_00280009" href ="#dicom_00280009"><dfn title="dicom_00280009" href ="#dicom_00280009">dicom:'Frame Increment Pointer'</dfn></a>: Required if Multi-frame Image. Contains the Data Element Tag of the attribute that is used as the Frame increment in Multi-frame image pixel data (see ).<p><a title="dicom_00280009" href ="#dicom_00280009">dicom:'Frame Increment Pointer'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
+                    <a title="dicom_00280009" href ="#dicom_00280009"><dfn title="dicom_00280009" href ="#dicom_00280009">dicom:'Frame Increment Pointer'</dfn></a>: Contains the Data Element Tag of the attribute that is used as the frame increment in Multi-frame pixel data.<p><a title="dicom_00280009" href ="#dicom_00280009">dicom:'Frame Increment Pointer'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
                 </div>
             </section>
             <!-- dicom:'Frame Dimension Pointer' (dicom_0028000A) -->
@@ -11062,7 +11062,7 @@
             <section id="dicom_003a0218">
                 <h2 label="dicom_003A0218">dicom:'Channel Offset'</h2>
                 <div class="glossary-ref">
-                    <a title="dicom_003A0218" href ="#dicom_003a0218"><dfn title="dicom_003A0218" href ="#dicom_003a0218">dicom:'Channel Offset'</dfn></a>: The offset in seconds from the beginning of the channel waveform data to the first sample to be used for presentation. Value may be negative.<p><a title="dicom_003A0218" href ="#dicom_003a0218">dicom:'Channel Offset'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
+                    <a title="dicom_003A0218" href ="#dicom_003a0218"><dfn title="dicom_003A0218" href ="#dicom_003a0218">dicom:'Channel Offset'</dfn></a>: Additional offset of first sample of channel to be used in aligning multiple channels for presentation or analysis, in seconds.<p><a title="dicom_003A0218" href ="#dicom_003a0218">dicom:'Channel Offset'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
                 </div>
             </section>
             <!-- dicom:'Waveform Bits Stored' (dicom_003A021A) -->
@@ -11216,7 +11216,7 @@
             <section id="dicom_0040000a">
                 <h2 label="dicom_0040000A">dicom:'Stage Code Sequence'</h2>
                 <div class="glossary-ref">
-                    <a title="dicom_0040000A" href ="#dicom_0040000a"><dfn title="dicom_0040000A" href ="#dicom_0040000a">dicom:'Stage Code Sequence'</dfn></a>: Sequence describing the performed Ultrasound Protocol Stage.<p><a title="dicom_0040000A" href ="#dicom_0040000a">dicom:'Stage Code Sequence'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
+                    <a title="dicom_0040000A" href ="#dicom_0040000a"><dfn title="dicom_0040000A" href ="#dicom_0040000a">dicom:'Stage Code Sequence'</dfn></a>: Sequence of items describing the performed Ultrasound Protocol Stage(s).<p><a title="dicom_0040000A" href ="#dicom_0040000a">dicom:'Stage Code Sequence'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
                 </div>
             </section>
             <!-- dicom:'Order Placer Identifier Sequence' (dicom_00400026) -->
@@ -12119,7 +12119,7 @@
             <section id="dicom_0040a493">
                 <h2 label="dicom_0040A493">dicom:'Verification Flag'</h2>
                 <div class="glossary-ref">
-                    <a title="dicom_0040A493" href ="#dicom_0040a493"><dfn title="dicom_0040A493" href ="#dicom_0040a493">dicom:'Verification Flag'</dfn></a>: Indicates whether the Encapsulated Document is Verified.<p><a title="dicom_0040A493" href ="#dicom_0040a493">dicom:'Verification Flag'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
+                    <a title="dicom_0040A493" href ="#dicom_0040a493"><dfn title="dicom_0040A493" href ="#dicom_0040a493">dicom:'Verification Flag'</dfn></a>: Indicates whether this SR Document is Verified.<p><a title="dicom_0040A493" href ="#dicom_0040a493">dicom:'Verification Flag'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
                 </div>
             </section>
             <!-- dicom:'Preliminary Flag' (dicom_0040A496) -->
@@ -15101,7 +15101,7 @@
             <section id="dicom_00700011">
                 <h2 label="dicom_00700011">dicom:'Bounding Box Bottom Right Hand Corner'</h2>
                 <div class="glossary-ref">
-                    <a title="dicom_00700011" href ="#dicom_00700011"><dfn title="dicom_00700011" href ="#dicom_00700011">dicom:'Bounding Box Bottom Right Hand Corner'</dfn></a>: Location of the Bottom Right Hand Corner (BRHC) of the bounding box in which Unformatted Text Value (0070,0006) is to be displayed, in Bounding Box Annotation Units (0070,0003), given as column/row. Column is the horizontal offset and row is the vertical offset.<p><a title="dicom_00700011" href ="#dicom_00700011">dicom:'Bounding Box Bottom Right Hand Corner'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
+                    <a title="dicom_00700011" href ="#dicom_00700011"><dfn title="dicom_00700011" href ="#dicom_00700011">dicom:'Bounding Box Bottom Right Hand Corner'</dfn></a>: Recommended location of the Bottom Right Hand Corner (BRHC) of the bounding box in which Unformatted Text Value (0070,0006) is to be displayed, as fractions of the specified presentation view width and height. Each value shall be within the range 0.0 to 1.0.<p><a title="dicom_00700011" href ="#dicom_00700011">dicom:'Bounding Box Bottom Right Hand Corner'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
                 </div>
             </section>
             <!-- dicom:'Bounding Box Text Horizontal Justification' (dicom_00700012) -->
@@ -15325,7 +15325,7 @@
             <section id="dicom_00700226">
                 <h2 label="dicom_00700226">dicom:'Compound Graphic Instance ID'</h2>
                 <div class="glossary-ref">
-                    <a title="dicom_00700226" href ="#dicom_00700226"><dfn title="dicom_00700226" href ="#dicom_00700226">dicom:'Compound Graphic Instance ID'</dfn></a>: The identifier of the Compound Graphic represented, in part, by this Item. The value of this attribute shall be equal to the value of Compound Graphic Instance ID (0070,0226) of the corresponding Item in the Compound Graphic Sequence (0070,0209).<p><a title="dicom_00700226" href ="#dicom_00700226">dicom:'Compound Graphic Instance ID'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
+                    <a title="dicom_00700226" href ="#dicom_00700226"><dfn title="dicom_00700226" href ="#dicom_00700226">dicom:'Compound Graphic Instance ID'</dfn></a>: A number that identifies the Compound Graphic described in this Item. The value shall be unique within this SOP instance.<p><a title="dicom_00700226" href ="#dicom_00700226">dicom:'Compound Graphic Instance ID'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
                 </div>
             </section>
             <!-- dicom:'Font Name' (dicom_00700227) -->
@@ -15605,7 +15605,7 @@
             <section id="dicom_00700295">
                 <h2 label="dicom_00700295">dicom:'Graphic Group ID'</h2>
                 <div class="glossary-ref">
-                    <a title="dicom_00700295" href ="#dicom_00700295"><dfn title="dicom_00700295" href ="#dicom_00700295">dicom:'Graphic Group ID'</dfn></a>: A number that defines the corresponding group object in the Graphic Group Sequence (0070,0234).<p><a title="dicom_00700295" href ="#dicom_00700295">dicom:'Graphic Group ID'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
+                    <a title="dicom_00700295" href ="#dicom_00700295"><dfn title="dicom_00700295" href ="#dicom_00700295">dicom:'Graphic Group ID'</dfn></a>: A unique number identifying the Graphic Group, i.e., the combined graphic object.<p><a title="dicom_00700295" href ="#dicom_00700295">dicom:'Graphic Group ID'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
                 </div>
             </section>
             <!-- dicom:'Shape Type' (dicom_00700306) -->
@@ -16676,7 +16676,7 @@
             <section id="dicom_00720330">
                 <h2 label="dicom_00720330">dicom:'Cine Relative to Real-Time'</h2>
                 <div class="glossary-ref">
-                    <a title="dicom_00720330" href ="#dicom_00720330"><dfn title="dicom_00720330" href ="#dicom_00720330">dicom:'Cine Relative to Real-Time'</dfn></a>: A positive unitless floating point numeric factor equal to playback rate divided by acquisition rate.<p><a title="dicom_00720330" href ="#dicom_00720330">dicom:'Cine Relative to Real-Time'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
+                    <a title="dicom_00720330" href ="#dicom_00720330"><dfn title="dicom_00720330" href ="#dicom_00720330">dicom:'Cine Relative to Real-Time'</dfn></a>: A positive dimensionless floating point numeric factor equal to playback rate divided by acquisition rate.<p><a title="dicom_00720330" href ="#dicom_00720330">dicom:'Cine Relative to Real-Time'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
                 </div>
             </section>
             <!-- dicom:'Filter Operations Sequence' (dicom_00720400) -->
@@ -18972,7 +18972,7 @@
             <section id="dicom_30080251">
                 <h2 label="dicom_30080251">dicom:'Treatment Time'</h2>
                 <div class="glossary-ref">
-                    <a title="dicom_30080251" href ="#dicom_30080251"><dfn title="dicom_30080251" href ="#dicom_30080251">dicom:'Treatment Time'</dfn></a>: Time when current fraction was delivered (begun), or Time last fraction was delivered (begun).<p><a title="dicom_30080251" href ="#dicom_30080251">dicom:'Treatment Time'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
+                    <a title="dicom_30080251" href ="#dicom_30080251"><dfn title="dicom_30080251" href ="#dicom_30080251">dicom:'Treatment Time'</dfn></a>: Time when fraction was delivered.<p><a title="dicom_30080251" href ="#dicom_30080251">dicom:'Treatment Time'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
                 </div>
             </section>
             <!-- dicom:'RT Plan Label' (dicom_300A0002) -->
@@ -19455,7 +19455,7 @@
             <section id="dicom_300a00b2">
                 <h2 label="dicom_300A00B2">dicom:'Treatment Machine Name'</h2>
                 <div class="glossary-ref">
-                    <a title="dicom_300A00B2" href ="#dicom_300a00b2"><dfn title="dicom_300A00B2" href ="#dicom_300a00b2">dicom:'Treatment Machine Name'</dfn></a>: User-defined name identifying treatment machine used for treatment delivery.<p><a title="dicom_300A00B2" href ="#dicom_300a00b2">dicom:'Treatment Machine Name'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
+                    <a title="dicom_300A00B2" href ="#dicom_300a00b2"><dfn title="dicom_300A00B2" href ="#dicom_300a00b2">dicom:'Treatment Machine Name'</dfn></a>: User-defined name identifying treatment machine to be used for treatment delivery.<p><a title="dicom_300A00B2" href ="#dicom_300a00b2">dicom:'Treatment Machine Name'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
                 </div>
             </section>
             <!-- dicom:'Primary Dosimeter Unit' (dicom_300A00B3) -->
@@ -19511,7 +19511,7 @@
             <section id="dicom_300a00c0">
                 <h2 label="dicom_300A00C0">dicom:'Beam Number'</h2>
                 <div class="glossary-ref">
-                    <a title="dicom_300A00C0" href ="#dicom_300a00c0"><dfn title="dicom_300A00C0" href ="#dicom_300a00c0">dicom:'Beam Number'</dfn></a>: Identification number of the beam.<p><a title="dicom_300A00C0" href ="#dicom_300a00c0">dicom:'Beam Number'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
+                    <a title="dicom_300A00C0" href ="#dicom_300a00c0"><dfn title="dicom_300A00C0" href ="#dicom_300a00c0">dicom:'Beam Number'</dfn></a>: Identification number of the Beam. The value of Beam Number (300A,00C0) shall be unique within the RT Plan in which it is created.<p><a title="dicom_300A00C0" href ="#dicom_300a00c0">dicom:'Beam Number'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
                 </div>
             </section>
             <!-- dicom:'Beam Name' (dicom_300A00C2) -->
@@ -20015,7 +20015,7 @@
             <section id="dicom_300a0121">
                 <h2 label="dicom_300A0121">dicom:'Beam Limiting Device Rotation Direction'</h2>
                 <div class="glossary-ref">
-                    <a title="dicom_300A0121" href ="#dicom_300a0121"><dfn title="dicom_300A0121" href ="#dicom_300a0121">dicom:'Beam Limiting Device Rotation Direction'</dfn></a>: Direction of Beam Limiting Device Rotation when viewing beam limiting device (collimator) from radiation source, for segment following Control Point.<p><a title="dicom_300A0121" href ="#dicom_300a0121">dicom:'Beam Limiting Device Rotation Direction'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
+                    <a title="dicom_300A0121" href ="#dicom_300a0121"><dfn title="dicom_300A0121" href ="#dicom_300a0121">dicom:'Beam Limiting Device Rotation Direction'</dfn></a>: Direction of Beam Limiting Device Rotation when viewing beam limiting device (collimator) from radiation source, for segment beginning at current Control Point.<p><a title="dicom_300A0121" href ="#dicom_300a0121">dicom:'Beam Limiting Device Rotation Direction'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
                 </div>
             </section>
             <!-- dicom:'Patient Support Angle' (dicom_300A0122) -->
@@ -20050,7 +20050,7 @@
             <section id="dicom_300a0126">
                 <h2 label="dicom_300A0126">dicom:'Table Top Eccentric Rotation Direction'</h2>
                 <div class="glossary-ref">
-                    <a title="dicom_300A0126" href ="#dicom_300a0126"><dfn title="dicom_300A0126" href ="#dicom_300a0126">dicom:'Table Top Eccentric Rotation Direction'</dfn></a>: Direction of Table Top Eccentric Rotation when viewing table from above, for segment beginning at current Control Point.<p><a title="dicom_300A0126" href ="#dicom_300a0126">dicom:'Table Top Eccentric Rotation Direction'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
+                    <a title="dicom_300A0126" href ="#dicom_300a0126"><dfn title="dicom_300A0126" href ="#dicom_300a0126">dicom:'Table Top Eccentric Rotation Direction'</dfn></a>: Direction of Table Top Eccentric Rotation when viewing table from above, for segment following Control Point.<p><a title="dicom_300A0126" href ="#dicom_300a0126">dicom:'Table Top Eccentric Rotation Direction'</a> is a <a title="DICOMTag" href ="./index.html#dicomtag">nidm:DICOMTag</a>.</p><p>Type: <a title="DatatypeProperty" href ="http://www.w3.org/2002/07/owl#DatatypeProperty">owl:DatatypeProperty</a><p>Curation Status: <a title="IAO_0000428" href ="./obo.html#iao_0000428">obo:IAO_0000428</a></p>
                 </div>
             </section>
             <!-- dicom:'Table Top Vertical Position' (dicom_300A0128) -->

--- a/doc/content/specs/nidm_html/obo.html
+++ b/doc/content/specs/nidm_html/obo.html
@@ -257,7 +257,7 @@
             <section id="iao_0000114">
                 <h2 label="IAO_0000114">obo:'has curation status'</h2>
                 <div class="glossary-ref">
-                    <a title="IAO_0000114" href ="#iao_0000114"><dfn title="IAO_0000114" href ="#iao_0000114">obo:'has curation status'</dfn></a>: <p><a title="IAO_0000114" href ="#iao_0000114">obo:'has curation status'</a> is a <a title="AnnotationProperty" href ="http://www.w3.org/2002/07/owl#AnnotationProperty">owl:AnnotationProperty</a>.</p><p>Type: <a title="AnnotationProperty" href ="http://www.w3.org/2002/07/owl#AnnotationProperty">owl:AnnotationProperty</a><p>Curation Status: <a title="IAO_0000124" href ="#iao_0000124">obo:'uncurated'</a></p><p>Editor: PERSON:Bill Bug
+                    <a title="IAO_0000114" href ="#iao_0000114"><dfn title="IAO_0000114" href ="#iao_0000114">obo:'has curation status'</dfn></a>: <p><a title="IAO_0000114" href ="#iao_0000114">obo:'has curation status'</a> is a <a title="AnnotationProperty" href ="http://www.w3.org/2002/07/owl#AnnotationProperty">owl:AnnotationProperty</a>.</p><p>Type: <a title="AnnotationProperty" href ="http://www.w3.org/2002/07/owl#AnnotationProperty">owl:AnnotationProperty</a><p>Curation Status: <a title="IAO_0000124" href ="#iao_0000124">obo:'uncurated'</a></p><p>Editor: PERSON:Alan Ruttenberg
                 </div>
             </section>
             <!-- obo:'definition' (IAO_0000115) -->

--- a/doc/content/specs/nidm_html/sio.html
+++ b/doc/content/specs/nidm_html/sio.html
@@ -779,7 +779,7 @@
             <section id="sio_000001">
                 <h2 label="SIO_000001">sio:'is related to'</h2>
                 <div class="glossary-ref">
-                    <a title="SIO_000001" href ="#sio_000001"><dfn title="SIO_000001" href ="#sio_000001">sio:'is related to'</dfn></a>: A is related to B iff there is some relation between A and B.<p><a title="SIO_000001" href ="#sio_000001">sio:'is related to'</a> is a <a title="ObjectProperty" href ="http://www.w3.org/2002/07/owl#ObjectProperty">owl:ObjectProperty</a>, <a title="SymmetricProperty" href ="http://www.w3.org/2002/07/owl#SymmetricProperty">owl:SymmetricProperty</a>.</p><p>Type: <a title="ObjectProperty" href ="http://www.w3.org/2002/07/owl#ObjectProperty">owl:ObjectProperty</a>, <a title="SymmetricProperty" href ="http://www.w3.org/2002/07/owl#SymmetricProperty">owl:SymmetricProperty</a><p>Curation Status: <a title="IAO_0000124" href ="./obo.html#iao_0000124">obo:IAO_0000124</a></p>
+                    <a title="SIO_000001" href ="#sio_000001"><dfn title="SIO_000001" href ="#sio_000001">sio:'is related to'</dfn></a>: A is related to B iff there is some relation between A and B.<p><a title="SIO_000001" href ="#sio_000001">sio:'is related to'</a> is a <a title="SymmetricProperty" href ="http://www.w3.org/2002/07/owl#SymmetricProperty">owl:SymmetricProperty</a>, <a title="ObjectProperty" href ="http://www.w3.org/2002/07/owl#ObjectProperty">owl:ObjectProperty</a>.</p><p>Type: <a title="SymmetricProperty" href ="http://www.w3.org/2002/07/owl#SymmetricProperty">owl:SymmetricProperty</a>, <a title="ObjectProperty" href ="http://www.w3.org/2002/07/owl#ObjectProperty">owl:ObjectProperty</a><p>Curation Status: <a title="IAO_0000124" href ="./obo.html#iao_0000124">obo:IAO_0000124</a></p>
                 </div>
             </section>
             <!-- sio:'has attribute' (SIO_000008) -->
@@ -793,7 +793,7 @@
             <section id="sio_000059">
                 <h2 label="SIO_000059">sio:'has member'</h2>
                 <div class="glossary-ref">
-                    <a title="SIO_000059" href ="#sio_000059"><dfn title="SIO_000059" href ="#sio_000059">sio:'has member'</dfn></a>: Has member is a mereological relation between a collection and an item.<p><a title="SIO_000059" href ="#sio_000059">sio:'has member'</a> is a <a title="SIO_000008" href ="#sio_000008">sio:'has attribute'</a>.</p><p>Type: <a title="ObjectProperty" href ="http://www.w3.org/2002/07/owl#ObjectProperty">owl:ObjectProperty</a>, <a title="IrreflexiveProperty" href ="http://www.w3.org/2002/07/owl#IrreflexiveProperty">owl:IrreflexiveProperty</a><p>Curation Status: <a title="IAO_0000124" href ="./obo.html#iao_0000124">obo:IAO_0000124</a></p>
+                    <a title="SIO_000059" href ="#sio_000059"><dfn title="SIO_000059" href ="#sio_000059">sio:'has member'</dfn></a>: Has member is a mereological relation between a collection and an item.<p><a title="SIO_000059" href ="#sio_000059">sio:'has member'</a> is a <a title="SIO_000008" href ="#sio_000008">sio:'has attribute'</a>.</p><p>Type: <a title="IrreflexiveProperty" href ="http://www.w3.org/2002/07/owl#IrreflexiveProperty">owl:IrreflexiveProperty</a>, <a title="ObjectProperty" href ="http://www.w3.org/2002/07/owl#ObjectProperty">owl:ObjectProperty</a><p>Curation Status: <a title="IAO_0000124" href ="./obo.html#iao_0000124">obo:IAO_0000124</a></p>
                 </div>
             </section>
             <!-- sio:'represents' (SIO_000210) -->

--- a/nidm/nidm-results/fsl/example001/fsl_nidm.json
+++ b/nidm/nidm-results/fsl/example001/fsl_nidm.json
@@ -1,5 +1,5 @@
 {
-  "@context": "http://purl.org/nidash/context", 
+  "@context": "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/nidmr.json", 
   "@id": "file:///home/karl/Work/INCF/nidm/nidm/nidm/nidm-results/fsl/example001/fsl_nidm.ttl", 
   "records": {
     "PeakDefinitionCriteria": {
@@ -18,42 +18,27 @@
       "@id": "niiri:software_id", 
       "featVersion": "6.00"
     }, 
-    "MaskMap": {
-      "prov:wasGeneratedBy": {
-        "@id": "niiri:model_parameters_estimation_id"
+    "DesignMatrix": {
+      "description": {
+        "@id": "niiri:design_matrix_png_id"
       }, 
-      "format": "image/nifti", 
-      "isUserDefined": false, 
-      "inCoordinateSpace": {
-        "@id": "niiri:coordinate_space_id_1"
+      "format": "text/csv", 
+      "hasDriftModel": {
+        "@id": "niiri:drift_model_id"
       }, 
-      "fileName": "Mask.nii.gz", 
+      "fileName": "DesignMatrix.csv", 
       "atLocation": {
         "@type": "xsd:anyURI", 
-        "@value": "Mask.nii.gz"
+        "@value": "DesignMatrix.csv"
       }, 
-      "crypto:sha512": "cc1a96a6111e5107eb08487e38e6d7f8164b9d1d3f1fc10948bdbcfaea642fe9bfae278c7fc372b65cac7232ea58fd8fb5914014e7b9a5d6200592b12b2a728b", 
-      "label": "Mask", 
-      "@id": "niiri:mask_id_1"
+      "hasHRFBasis": {
+        "@id": "fsl:FSL_0000001"
+      }, 
+      "regressorNames": "[\"Gen\", \"Gen*temporal_derivative\", \"Shad\", \"Shad*temporal_derivative\"]", 
+      "label": "Design Matrix", 
+      "@id": "niiri:design_matrix_id"
     }, 
     "ParameterEstimateMap": [
-      {
-        "prov:wasGeneratedBy": {
-          "@id": "niiri:model_parameters_estimation_id"
-        }, 
-        "format": "image/nifti", 
-        "inCoordinateSpace": {
-          "@id": "niiri:coordinate_space_id_1"
-        }, 
-        "fileName": "ParameterEstimate_003.nii.gz", 
-        "atLocation": {
-          "@type": "xsd:anyURI", 
-          "@value": "ParameterEstimate_003.nii.gz"
-        }, 
-        "crypto:sha512": "f5dd8123b389fe755086f7ad3becb5b79f39d70cf0095b08ed8c3e5cb717942711264528f08fa99e58aaaf24e03581c64567864110518247d95031ef3fe2e761", 
-        "label": "Parameter estimate 3", 
-        "@id": "niiri:beta_map_id_3"
-      }, 
       {
         "prov:wasGeneratedBy": {
           "@id": "niiri:model_parameters_estimation_id"
@@ -104,6 +89,23 @@
         "crypto:sha512": "aca2503769bfb6ee3801bc50c2e033755cd9844d13ee78a38aa23140ad558b5c6f0517c4748f84acac27cf6608222553003f418097c18f254312b49b5522b831", 
         "label": "Parameter estimate 4", 
         "@id": "niiri:beta_map_id_4"
+      }, 
+      {
+        "prov:wasGeneratedBy": {
+          "@id": "niiri:model_parameters_estimation_id"
+        }, 
+        "format": "image/nifti", 
+        "inCoordinateSpace": {
+          "@id": "niiri:coordinate_space_id_1"
+        }, 
+        "fileName": "ParameterEstimate_003.nii.gz", 
+        "atLocation": {
+          "@type": "xsd:anyURI", 
+          "@value": "ParameterEstimate_003.nii.gz"
+        }, 
+        "crypto:sha512": "f5dd8123b389fe755086f7ad3becb5b79f39d70cf0095b08ed8c3e5cb717942711264528f08fa99e58aaaf24e03581c64567864110518247d95031ef3fe2e761", 
+        "label": "Parameter estimate 3", 
+        "@id": "niiri:beta_map_id_3"
       }
     ], 
     "SupraThresholdCluster": [
@@ -154,14 +156,23 @@
       "@id": "niiri:d4de4b20b2d408cd8d825ac0edb6030a", 
       "format": "image/nifti"
     }, 
-    "HeightThreshold": {
-      "@id": "niiri:height_threshold_id", 
-      "@type": "Statistic", 
-      "prov:value": {
-        "@type": "xsd:float", 
-        "@value": "2.3"
+    "MaskMap": {
+      "prov:wasGeneratedBy": {
+        "@id": "niiri:model_parameters_estimation_id"
       }, 
-      "label": "Height Threshold: Z>2.3"
+      "format": "image/nifti", 
+      "isUserDefined": false, 
+      "inCoordinateSpace": {
+        "@id": "niiri:coordinate_space_id_1"
+      }, 
+      "fileName": "Mask.nii.gz", 
+      "atLocation": {
+        "@type": "xsd:anyURI", 
+        "@value": "Mask.nii.gz"
+      }, 
+      "crypto:sha512": "cc1a96a6111e5107eb08487e38e6d7f8164b9d1d3f1fc10948bdbcfaea642fe9bfae278c7fc372b65cac7232ea58fd8fb5914014e7b9a5d6200592b12b2a728b", 
+      "label": "Mask", 
+      "@id": "niiri:mask_id_1"
     }, 
     "ExtentThreshold": {
       "@id": "niiri:extent_threshold_id", 
@@ -189,7 +200,7 @@
         "@type": "xsd:dateTime", 
         "@value": "2014-05-19T10:30:00+01:00"
       }, 
-      "@id": "_:f1e385922049a4c1cabd79d026ff24b4db1", 
+      "@id": "_:fc7f7d70abdb54db88b15d5d3a3028aebb1", 
       "prov:activity": {
         "@id": "niiri:export_id"
       }
@@ -222,6 +233,30 @@
         "prov:wasDerivedFrom": {
           "@id": "niiri:supra_threshold_cluster_0003"
         }, 
+        "equivalentZStatistic": "5.61", 
+        "pValueUncorrected": "1.01163e-08", 
+        "label": "Peak 3_01", 
+        "atLocation": {
+          "@id": "niiri:coordinate_0003_1"
+        }, 
+        "@id": "niiri:peak_0003_1"
+      }, 
+      {
+        "prov:wasDerivedFrom": {
+          "@id": "niiri:supra_threshold_cluster_0003"
+        }, 
+        "equivalentZStatistic": "5.12", 
+        "pValueUncorrected": "1.52768e-07", 
+        "label": "Peak 3_02", 
+        "atLocation": {
+          "@id": "niiri:coordinate_0003_2"
+        }, 
+        "@id": "niiri:peak_0003_2"
+      }, 
+      {
+        "prov:wasDerivedFrom": {
+          "@id": "niiri:supra_threshold_cluster_0003"
+        }, 
         "equivalentZStatistic": "4.22", 
         "pValueUncorrected": "1.22151e-05", 
         "label": "Peak 3_05", 
@@ -244,18 +279,6 @@
       }, 
       {
         "prov:wasDerivedFrom": {
-          "@id": "niiri:supra_threshold_cluster_0003"
-        }, 
-        "equivalentZStatistic": "4.12", 
-        "pValueUncorrected": "1.89436e-05", 
-        "label": "Peak 3_06", 
-        "atLocation": {
-          "@id": "niiri:coordinate_0003_6"
-        }, 
-        "@id": "niiri:peak_0003_6"
-      }, 
-      {
-        "prov:wasDerivedFrom": {
           "@id": "niiri:supra_threshold_cluster_0001"
         }, 
         "equivalentZStatistic": "2.54", 
@@ -265,18 +288,6 @@
           "@id": "niiri:coordinate_0001_4"
         }, 
         "@id": "niiri:peak_0001_4"
-      }, 
-      {
-        "prov:wasDerivedFrom": {
-          "@id": "niiri:supra_threshold_cluster_0001"
-        }, 
-        "equivalentZStatistic": "3.16", 
-        "pValueUncorrected": "0.000788846", 
-        "label": "Peak 1_02", 
-        "atLocation": {
-          "@id": "niiri:coordinate_0001_2"
-        }, 
-        "@id": "niiri:peak_0001_2"
       }, 
       {
         "prov:wasDerivedFrom": {
@@ -304,15 +315,15 @@
       }, 
       {
         "prov:wasDerivedFrom": {
-          "@id": "niiri:supra_threshold_cluster_0003"
+          "@id": "niiri:supra_threshold_cluster_0001"
         }, 
-        "equivalentZStatistic": "5.61", 
-        "pValueUncorrected": "1.01163e-08", 
-        "label": "Peak 3_01", 
+        "equivalentZStatistic": "3.16", 
+        "pValueUncorrected": "0.000788846", 
+        "label": "Peak 1_02", 
         "atLocation": {
-          "@id": "niiri:coordinate_0003_1"
+          "@id": "niiri:coordinate_0001_2"
         }, 
-        "@id": "niiri:peak_0003_1"
+        "@id": "niiri:peak_0001_2"
       }, 
       {
         "prov:wasDerivedFrom": {
@@ -337,6 +348,18 @@
           "@id": "niiri:coordinate_0004_3"
         }, 
         "@id": "niiri:peak_0004_3"
+      }, 
+      {
+        "prov:wasDerivedFrom": {
+          "@id": "niiri:supra_threshold_cluster_0004"
+        }, 
+        "equivalentZStatistic": "5.79", 
+        "pValueUncorrected": "3.51932e-09", 
+        "label": "Peak 4_01", 
+        "atLocation": {
+          "@id": "niiri:coordinate_0004_1"
+        }, 
+        "@id": "niiri:peak_0004_1"
       }, 
       {
         "prov:wasDerivedFrom": {
@@ -378,18 +401,6 @@
         "prov:wasDerivedFrom": {
           "@id": "niiri:supra_threshold_cluster_0003"
         }, 
-        "equivalentZStatistic": "5.12", 
-        "pValueUncorrected": "1.52768e-07", 
-        "label": "Peak 3_02", 
-        "atLocation": {
-          "@id": "niiri:coordinate_0003_2"
-        }, 
-        "@id": "niiri:peak_0003_2"
-      }, 
-      {
-        "prov:wasDerivedFrom": {
-          "@id": "niiri:supra_threshold_cluster_0003"
-        }, 
         "equivalentZStatistic": "4.63", 
         "pValueUncorrected": "1.82833e-06", 
         "label": "Peak 3_03", 
@@ -400,15 +411,15 @@
       }, 
       {
         "prov:wasDerivedFrom": {
-          "@id": "niiri:supra_threshold_cluster_0004"
+          "@id": "niiri:supra_threshold_cluster_0003"
         }, 
-        "equivalentZStatistic": "5.79", 
-        "pValueUncorrected": "3.51932e-09", 
-        "label": "Peak 4_01", 
+        "equivalentZStatistic": "4.12", 
+        "pValueUncorrected": "1.89436e-05", 
+        "label": "Peak 3_06", 
         "atLocation": {
-          "@id": "niiri:coordinate_0004_1"
+          "@id": "niiri:coordinate_0003_6"
         }, 
-        "@id": "niiri:peak_0004_1"
+        "@id": "niiri:peak_0003_6"
       }, 
       {
         "prov:wasDerivedFrom": {
@@ -464,10 +475,10 @@
           "@id": "niiri:residual_mean_squares_map_id"
         }, 
         {
-          "@id": "niiri:contrast_id_1"
+          "@id": "niiri:beta_map_id_1"
         }, 
         {
-          "@id": "niiri:beta_map_id_1"
+          "@id": "niiri:contrast_id_1"
         }, 
         {
           "@id": "niiri:mask_id_1"
@@ -503,10 +514,10 @@
       }, 
       "prov:wasAttributedTo": [
         {
-          "@id": "niiri:mr_scanner_id"
+          "@id": "niiri:subject_id"
         }, 
         {
-          "@id": "niiri:subject_id"
+          "@id": "niiri:mr_scanner_id"
         }
       ], 
       "targetIntensity": "10000.0", 
@@ -524,13 +535,13 @@
     "ModelParameterEstimation": {
       "prov:used": [
         {
+          "@id": "niiri:error_model_id"
+        }, 
+        {
           "@id": "niiri:design_matrix_id"
         }, 
         {
           "@id": "niiri:data_id"
-        }, 
-        {
-          "@id": "niiri:error_model_id"
         }
       ], 
       "prov:wasAssociatedWith": {
@@ -620,45 +631,13 @@
     }, 
     "NIDMResults": {
       "prov:qualifiedGeneration": {
-        "@id": "_:f1e385922049a4c1cabd79d026ff24b4db1"
+        "@id": "_:fc7f7d70abdb54db88b15d5d3a3028aebb1"
       }, 
       "version": "1.3.0", 
       "@id": "niiri:fsl_results_id", 
       "label": "NIDM-Results"
     }, 
-    "DesignMatrix": {
-      "description": {
-        "@id": "niiri:design_matrix_png_id"
-      }, 
-      "format": "text/csv", 
-      "hasDriftModel": {
-        "@id": "niiri:drift_model_id"
-      }, 
-      "fileName": "DesignMatrix.csv", 
-      "atLocation": {
-        "@type": "xsd:anyURI", 
-        "@value": "DesignMatrix.csv"
-      }, 
-      "hasHRFBasis": {
-        "@id": "fsl:FSL_0000001"
-      }, 
-      "regressorNames": "[\"Gen\", \"Gen*temporal_derivative\", \"Shad\", \"Shad*temporal_derivative\"]", 
-      "label": "Design Matrix", 
-      "@id": "niiri:design_matrix_id"
-    }, 
     "Coordinate": [
-      {
-        "coordinateVectorInVoxels": "[ 32.3, 39.2, 31.0 ]", 
-        "label": "Coordinate 0001", 
-        "@id": "niiri:COG_coordinate_0001", 
-        "coordinateVector": "[ -4.39, 28.6, 55.9 ]"
-      }, 
-      {
-        "coordinateVectorInVoxels": "[ 48, 37, 21 ]", 
-        "label": "Coordinate 3_03", 
-        "@id": "niiri:coordinate_0003_3", 
-        "coordinateVector": "[-59.5, 21.0, 21.0]"
-      }, 
       {
         "coordinateVectorInVoxels": "[ 43.4, 40.3, 23.9 ]", 
         "label": "Coordinate 0003", 
@@ -672,22 +651,22 @@
         "coordinateVector": "[ -35.0, -49.0, -7.0 ]"
       }, 
       {
+        "coordinateVectorInVoxels": "[ 42, 21, 12 ]", 
+        "label": "Coordinate 4_02", 
+        "@id": "niiri:coordinate_0004_2", 
+        "coordinateVector": "[-38.5, -35.0, -10.5]"
+      }, 
+      {
         "coordinateVectorInVoxels": "[ 32, 10, 16 ]", 
         "label": "Coordinate 4_06", 
         "@id": "niiri:coordinate_0004_6", 
         "coordinateVector": "[-3.5, -73.5, 3.5]"
       }, 
       {
-        "coordinateVectorInVoxels": "[ 33, 38, 31 ]", 
-        "label": "Coordinate 1_01", 
-        "@id": "niiri:coordinate_0001_1", 
-        "coordinateVector": "[-7.0, 24.5, 56.0]"
-      }, 
-      {
-        "coordinateVectorInVoxels": "[ 43, 41, 20 ]", 
-        "label": "Coordinate 3_02", 
-        "@id": "niiri:coordinate_0003_2", 
-        "coordinateVector": "[-42.0, 35.0, 17.5]"
+        "coordinateVectorInVoxels": "[ 48, 37, 21 ]", 
+        "label": "Coordinate 3_03", 
+        "@id": "niiri:coordinate_0003_3", 
+        "coordinateVector": "[-59.5, 21.0, 21.0]"
       }, 
       {
         "coordinateVectorInVoxels": "[ 47.1, 19.2, 19.7 ]", 
@@ -708,10 +687,22 @@
         "coordinateVector": "[-56.0, -45.5, 10.5]"
       }, 
       {
+        "coordinateVectorInVoxels": "[ 32.3, 39.2, 31.0 ]", 
+        "label": "Coordinate 0001", 
+        "@id": "niiri:COG_coordinate_0001", 
+        "coordinateVector": "[ -4.39, 28.6, 55.9 ]"
+      }, 
+      {
         "coordinateVectorInVoxels": "[ 34.0, 14.7, 14.0 ]", 
         "label": "Coordinate 0004", 
         "@id": "niiri:COG_coordinate_0004", 
         "coordinateVector": "[-10.5, -56.9, -3.41]"
+      }, 
+      {
+        "coordinateVectorInVoxels": "[ 43, 41, 20 ]", 
+        "label": "Coordinate 3_02", 
+        "@id": "niiri:coordinate_0003_2", 
+        "coordinateVector": "[-42.0, 35.0, 17.5]"
       }, 
       {
         "coordinateVectorInVoxels": "[ 41, 41, 25 ]", 
@@ -750,10 +741,10 @@
         "coordinateVector": "[-7.0, 52.5, 42.0]"
       }, 
       {
-        "coordinateVectorInVoxels": "[ 42, 21, 12 ]", 
-        "label": "Coordinate 4_02", 
-        "@id": "niiri:coordinate_0004_2", 
-        "coordinateVector": "[-38.5, -35.0, -10.5]"
+        "coordinateVectorInVoxels": "[ 33, 38, 31 ]", 
+        "label": "Coordinate 1_01", 
+        "@id": "niiri:coordinate_0001_1", 
+        "coordinateVector": "[-7.0, 24.5, 56.0]"
       }, 
       {
         "coordinateVectorInVoxels": "[ 33, 43, 28 ]", 
@@ -801,13 +792,10 @@
     "Inference": {
       "prov:used": [
         {
-          "@id": "niiri:z_statistic_map_id_1"
+          "@id": "niiri:cluster_definition_criteria_id_1"
         }, 
         {
           "@id": "niiri:extent_threshold_id"
-        }, 
-        {
-          "@id": "niiri:mask_id_1"
         }, 
         {
           "@id": "niiri:height_threshold_id"
@@ -816,7 +804,10 @@
           "@id": "niiri:peak_definition_criteria_id_1"
         }, 
         {
-          "@id": "niiri:cluster_definition_criteria_id_1"
+          "@id": "niiri:mask_id_1"
+        }, 
+        {
+          "@id": "niiri:z_statistic_map_id_1"
         }
       ], 
       "prov:wasAssociatedWith": {
@@ -931,6 +922,15 @@
     "prov:Person": {
       "@id": "niiri:subject_id", 
       "label": "Person"
+    }, 
+    "Statistic": {
+      "@id": "niiri:height_threshold_id", 
+      "@type": "HeightThreshold", 
+      "prov:value": {
+        "@type": "xsd:float", 
+        "@value": "2.3"
+      }, 
+      "label": "Height Threshold: Z>2.3"
     }, 
     "ClusterDefinitionCriteria": {
       "@id": "niiri:cluster_definition_criteria_id_1", 

--- a/nidm/nidm-results/scripts/create_example_from_templates.py
+++ b/nidm/nidm-results/scripts/create_example_from_templates.py
@@ -157,9 +157,9 @@ class ExampleFromTemplate(object):
 
                 # context = {"@context":
                 #            os.path.join(TPL_DIR, "..", "nidmr.json")}
-                foo = ld.jsonld.compact(json.loads(g2), 
-# KGH remove purl                                       'http://purl.org/nidash/context')
-                                        'https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/nidmr.json')
+                foo = ld.jsonld.compact(json.loads(g2),
+                                        'http://purl.org/nidash/context')
+# KGH try direct load of context file   'https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/nidmr.json')
                 with open(self.file.replace('.ttl', '.json'), "w") as fid:
                     fid.write(json.dumps(foo, indent=2))
 

--- a/nidm/nidm-results/spm/example001/example001_spm_results.json
+++ b/nidm/nidm-results/spm/example001/example001_spm_results.json
@@ -1,5 +1,5 @@
 {
-  "@context": "http://purl.org/nidash/context", 
+  "@context": "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/nidmr.json", 
   "@id": "file:///home/karl/Work/INCF/nidm/nidm/nidm/nidm-results/spm/example001/example001_spm_results.ttl", 
   "records": {
     "PeakDefinitionCriteria": {
@@ -7,6 +7,11 @@
       "minDistanceBetweenPeaks": "8.0", 
       "@id": "niiri:peak_definition_criteria_id", 
       "label": "Peak Definition Criteria"
+    }, 
+    "DiscreteCosineTransformbasisDriftModel": {
+      "SPMsDriftCutoffPeriod": "128.0", 
+      "@id": "niiri:drift_model_id", 
+      "label": "SPM's DCT Drift Model"
     }, 
     "DesignMatrix": {
       "description": {
@@ -28,39 +33,6 @@
       "label": "Design Matrix", 
       "@id": "niiri:design_matrix_id"
     }, 
-    "DiscreteCosineTransformbasisDriftModel": {
-      "SPMsDriftCutoffPeriod": "128.0", 
-      "@id": "niiri:drift_model_id", 
-      "label": "SPM's DCT Drift Model"
-    }, 
-    "HeightThreshold": [
-      {
-        "equivalentThreshold": [
-          {
-            "@id": "niiri:height_threshold_id_2"
-          }, 
-          {
-            "@id": "niiri:height_threshold_id_3"
-          }
-        ], 
-        "@id": "niiri:height_threshold_id", 
-        "@type": "FWERAdjustedPValue", 
-        "prov:value": {
-          "@type": "xsd:float", 
-          "@value": "0.05"
-        }, 
-        "label": "Height Threshold: p<0.050000 (FWE)"
-      }, 
-      {
-        "@id": "niiri:height_threshold_id_2", 
-        "@type": "Statistic", 
-        "prov:value": {
-          "@type": "xsd:float", 
-          "@value": "4.8524174569"
-        }, 
-        "label": "Height Threshold"
-      }
-    ], 
     "spm": {
       "softwareVersion": "12b.5858", 
       "@id": "niiri:exporter_id", 
@@ -151,14 +123,14 @@
         "prov:wasDerivedFrom": {
           "@id": "niiri:excursion_set_map_id"
         }, 
-        "pValueFWER": "0.0", 
-        "clusterSizeInVoxels": "839", 
-        "pValueUncorrected": "3.5589682448e-19", 
-        "qValueFDR": "1.7794841224e-18", 
-        "clusterSizeInResels": "6.31265696809", 
-        "clusterLabelId": "1", 
-        "label": "Supra-Threshold Cluster: 0001", 
-        "@id": "niiri:supra_threshold_cluster_0001"
+        "pValueFWER": "0.000565384750378", 
+        "clusterSizeInVoxels": "29", 
+        "pValueUncorrected": "0.0110257032105", 
+        "qValueFDR": "0.0137821290131", 
+        "clusterSizeInResels": "0.218196724761", 
+        "clusterLabelId": "4", 
+        "label": "Supra-Threshold Cluster: 0004", 
+        "@id": "niiri:supra_threshold_cluster_0004"
       }, 
       {
         "prov:wasDerivedFrom": {
@@ -177,44 +149,41 @@
         "prov:wasDerivedFrom": {
           "@id": "niiri:excursion_set_map_id"
         }, 
-        "pValueFWER": "0.000565384750378", 
-        "clusterSizeInVoxels": "29", 
-        "pValueUncorrected": "0.0110257032105", 
-        "qValueFDR": "0.0137821290131", 
-        "clusterSizeInResels": "0.218196724761", 
-        "clusterLabelId": "4", 
-        "label": "Supra-Threshold Cluster: 0004", 
-        "@id": "niiri:supra_threshold_cluster_0004"
+        "pValueFWER": "0.0", 
+        "clusterSizeInVoxels": "839", 
+        "pValueUncorrected": "3.5589682448e-19", 
+        "qValueFDR": "1.7794841224e-18", 
+        "clusterSizeInResels": "6.31265696809", 
+        "clusterLabelId": "1", 
+        "label": "Supra-Threshold Cluster: 0001", 
+        "@id": "niiri:supra_threshold_cluster_0001"
       }
     ], 
-    "PValueUncorrected": [
-      {
-        "@id": "niiri:extent_threshold_id_3", 
-        "@type": "ExtentThreshold", 
-        "prov:value": {
-          "@type": "xsd:float", 
-          "@value": "1.0"
-        }, 
-        "label": "Extent Threshold"
-      }, 
-      {
-        "@id": "niiri:height_threshold_id_3", 
-        "@type": "HeightThreshold", 
-        "prov:value": {
-          "@type": "xsd:float", 
-          "@value": "2.7772578457e-06"
-        }, 
-        "label": "Height Threshold"
-      }
-    ], 
-    "FWERAdjustedPValue": {
-      "@id": "niiri:extent_threshold_id_2", 
-      "@type": "ExtentThreshold", 
+    "PValueUncorrected": {
+      "@id": "niiri:height_threshold_id_3", 
+      "@type": "HeightThreshold", 
       "prov:value": {
         "@type": "xsd:float", 
-        "@value": "1.0"
+        "@value": "2.7772578457e-06"
       }, 
-      "label": "Extent Threshold"
+      "label": "Height Threshold"
+    }, 
+    "FWERAdjustedPValue": {
+      "equivalentThreshold": [
+        {
+          "@id": "niiri:height_threshold_id_2"
+        }, 
+        {
+          "@id": "niiri:height_threshold_id_3"
+        }
+      ], 
+      "@id": "niiri:height_threshold_id", 
+      "@type": "HeightThreshold", 
+      "prov:value": {
+        "@type": "xsd:float", 
+        "@value": "0.05"
+      }, 
+      "label": "Height Threshold: p<0.050000 (FWE)"
     }, 
     "MaskMap": [
       {
@@ -245,6 +214,41 @@
         "@id": "niiri:mask_id_1"
       }
     ], 
+    "ExtentThreshold": [
+      {
+        "equivalentThreshold": [
+          {
+            "@id": "niiri:extent_threshold_id_2"
+          }, 
+          {
+            "@id": "niiri:extent_threshold_id_3"
+          }
+        ], 
+        "clusterSizeInVoxels": "0", 
+        "label": "Extent Threshold: k>=0", 
+        "clusterSizeInResels": "0.0", 
+        "@id": "niiri:extent_threshold_id", 
+        "@type": "Statistic"
+      }, 
+      {
+        "@id": "niiri:extent_threshold_id_2", 
+        "@type": "FWERAdjustedPValue", 
+        "prov:value": {
+          "@type": "xsd:float", 
+          "@value": "1.0"
+        }, 
+        "label": "Extent Threshold"
+      }, 
+      {
+        "@id": "niiri:extent_threshold_id_3", 
+        "@type": "PValueUncorrected", 
+        "prov:value": {
+          "@type": "xsd:float", 
+          "@value": "1.0"
+        }, 
+        "label": "Extent Threshold"
+      }
+    ], 
     "CoordinateSpace": {
       "voxelUnits": "[ \"mm\", \"mm\", \"mm\" ]", 
       "dimensionsInVoxels": "[ 53, 63, 52 ]", 
@@ -262,7 +266,7 @@
         "@type": "xsd:dateTime", 
         "@value": "2014-05-19T10:30:00+01:00"
       }, 
-      "@id": "_:fc6cbe8eecd3a469882bc1f3a5dd9be95b1", 
+      "@id": "_:f3c0f978cc1a24f46a40fbde164433094b1", 
       "prov:activity": {
         "@id": "niiri:export_id"
       }
@@ -295,6 +299,24 @@
     "Peak": [
       {
         "prov:wasDerivedFrom": {
+          "@id": "niiri:supra_threshold_cluster_0005"
+        }, 
+        "pValueFWER": "0.0119099090974", 
+        "equivalentZStatistic": "4.8868208549", 
+        "pValueUncorrected": "5.12386299834e-07", 
+        "qValueFDR": "0.251554254718", 
+        "prov:value": {
+          "@type": "xsd:float", 
+          "@value": "5.27320194244"
+        }, 
+        "label": "Peak: 0009", 
+        "atLocation": {
+          "@id": "niiri:coordinate_0009"
+        }, 
+        "@id": "niiri:peak_0009"
+      }, 
+      {
+        "prov:wasDerivedFrom": {
           "@id": "niiri:supra_threshold_cluster_0001"
         }, 
         "pValueFWER": "0.0", 
@@ -313,21 +335,39 @@
       }, 
       {
         "prov:wasDerivedFrom": {
-          "@id": "niiri:supra_threshold_cluster_0005"
+          "@id": "niiri:supra_threshold_cluster_0002"
         }, 
-        "pValueFWER": "0.0119099090974", 
-        "equivalentZStatistic": "4.8868208549", 
-        "pValueUncorrected": "5.12386299834e-07", 
-        "qValueFDR": "0.251554254718", 
+        "pValueFWER": "0.0", 
+        "equivalentZStatistic": "inf", 
+        "pValueUncorrected": "4.4408920985e-16", 
+        "qValueFDR": "1.19156591714e-11", 
         "prov:value": {
           "@type": "xsd:float", 
-          "@value": "5.27320194244"
+          "@value": "13.5425577164"
         }, 
-        "label": "Peak: 0009", 
+        "label": "Peak: 0004", 
         "atLocation": {
-          "@id": "niiri:coordinate_0009"
+          "@id": "niiri:coordinate_0004"
         }, 
-        "@id": "niiri:peak_0009"
+        "@id": "niiri:peak_0004"
+      }, 
+      {
+        "prov:wasDerivedFrom": {
+          "@id": "niiri:supra_threshold_cluster_0001"
+        }, 
+        "pValueFWER": "0.0", 
+        "equivalentZStatistic": "inf", 
+        "pValueUncorrected": "4.4408920985e-16", 
+        "qValueFDR": "1.19156591714e-11", 
+        "prov:value": {
+          "@type": "xsd:float", 
+          "@value": "17.5207633972"
+        }, 
+        "label": "Peak: 0001", 
+        "atLocation": {
+          "@id": "niiri:coordinate_0001"
+        }, 
+        "@id": "niiri:peak_0001"
       }, 
       {
         "prov:wasDerivedFrom": {
@@ -364,24 +404,6 @@
           "@id": "niiri:coordinate_0005"
         }, 
         "@id": "niiri:peak_0005"
-      }, 
-      {
-        "prov:wasDerivedFrom": {
-          "@id": "niiri:supra_threshold_cluster_0002"
-        }, 
-        "pValueFWER": "0.0", 
-        "equivalentZStatistic": "inf", 
-        "pValueUncorrected": "4.4408920985e-16", 
-        "qValueFDR": "1.19156591714e-11", 
-        "prov:value": {
-          "@type": "xsd:float", 
-          "@value": "13.5425577164"
-        }, 
-        "label": "Peak: 0004", 
-        "atLocation": {
-          "@id": "niiri:coordinate_0004"
-        }, 
-        "@id": "niiri:peak_0004"
       }, 
       {
         "prov:wasDerivedFrom": {
@@ -436,24 +458,6 @@
           "@id": "niiri:coordinate_0008"
         }, 
         "@id": "niiri:peak_0008"
-      }, 
-      {
-        "prov:wasDerivedFrom": {
-          "@id": "niiri:supra_threshold_cluster_0001"
-        }, 
-        "pValueFWER": "0.0", 
-        "equivalentZStatistic": "inf", 
-        "pValueUncorrected": "4.4408920985e-16", 
-        "qValueFDR": "1.19156591714e-11", 
-        "prov:value": {
-          "@type": "xsd:float", 
-          "@value": "17.5207633972"
-        }, 
-        "label": "Peak: 0001", 
-        "atLocation": {
-          "@id": "niiri:coordinate_0001"
-        }, 
-        "@id": "niiri:peak_0001"
       }
     ], 
     "ResidualMeanSquaresMap": [
@@ -493,19 +497,19 @@
           "@id": "niiri:design_matrix_id"
         }, 
         {
+          "@id": "niiri:contrast_id"
+        }, 
+        {
           "@id": "niiri:mask_id_1"
         }, 
         {
           "@id": "niiri:beta_map_id_2"
         }, 
         {
-          "@id": "niiri:beta_map_id_1"
-        }, 
-        {
-          "@id": "niiri:contrast_id"
-        }, 
-        {
           "@id": "niiri:residual_mean_squares_map_id"
+        }, 
+        {
+          "@id": "niiri:beta_map_id_1"
         }
       ], 
       "@id": "niiri:contrast_estimation_id", 
@@ -552,6 +556,12 @@
     }, 
     "ReselsPerVoxelMap": [
       {
+        "crypto:sha512": "963283cdde607c40e4640c27453867bd0d70133b6d61482933862487c0f4a5acdb2e338a12a2605ee044b1aa47b5717f0c520b90ed3c49b5227f0483bd48512d", 
+        "fileName": "RPV.nii", 
+        "@id": "niiri:resels_per_voxel_map_id_der", 
+        "format": "image/nifti"
+      }, 
+      {
         "prov:wasDerivedFrom": {
           "@id": "niiri:resels_per_voxel_map_id_der"
         }, 
@@ -570,12 +580,6 @@
         "crypto:sha512": "2025dc6c33708b80708c2eba3215fb1149df236fb558a8e8f8f6cf34595fb54734fe5e436db3e192a424d99699dd7feb2f4a9020ceae8e7bcbd881b17825256a", 
         "label": "Resels per Voxel Map", 
         "@id": "niiri:resels_per_voxel_map_id"
-      }, 
-      {
-        "crypto:sha512": "963283cdde607c40e4640c27453867bd0d70133b6d61482933862487c0f4a5acdb2e338a12a2605ee044b1aa47b5717f0c520b90ed3c49b5227f0483bd48512d", 
-        "fileName": "RPV.nii", 
-        "@id": "niiri:resels_per_voxel_map_id_der", 
-        "format": "image/nifti"
       }
     ], 
     "NIDMResultsExport": {
@@ -585,16 +589,21 @@
       "@id": "niiri:export_id", 
       "label": "NIDM-Results export"
     }, 
+    "Magnetic resonance imaging scanner": {
+      "@id": "niiri:mr_scanner_id", 
+      "@type": "Imaging instrument", 
+      "label": "MRI Scanner"
+    }, 
     "ModelParameterEstimation": {
       "prov:used": [
         {
-          "@id": "niiri:design_matrix_id"
+          "@id": "niiri:error_model_id"
         }, 
         {
           "@id": "niiri:data_id"
         }, 
         {
-          "@id": "niiri:error_model_id"
+          "@id": "niiri:design_matrix_id"
         }
       ], 
       "prov:wasAssociatedWith": {
@@ -653,14 +662,9 @@
         "format": "image/png"
       }
     ], 
-    "Imaging instrument": {
-      "@id": "niiri:mr_scanner_id", 
-      "@type": "Magnetic resonance imaging scanner", 
-      "label": "MRI Scanner"
-    }, 
     "NIDMResults": {
       "prov:qualifiedGeneration": {
-        "@id": "_:fc6cbe8eecd3a469882bc1f3a5dd9be95b1"
+        "@id": "_:f3c0f978cc1a24f46a40fbde164433094b1"
       }, 
       "version": "1.3.0", 
       "@id": "niiri:spm_results_id", 
@@ -713,6 +717,15 @@
         "coordinateVector": "[ 45, -40, 32 ]"
       }
     ], 
+    "HeightThreshold": {
+      "@id": "niiri:height_threshold_id_2", 
+      "@type": "Statistic", 
+      "prov:value": {
+        "@type": "xsd:float", 
+        "@value": "4.8524174569"
+      }, 
+      "label": "Height Threshold"
+    }, 
     "ContrastMap": [
       {
         "prov:wasDerivedFrom": {
@@ -745,25 +758,25 @@
     "Inference": {
       "prov:used": [
         {
-          "@id": "niiri:statistic_map_id"
-        }, 
-        {
-          "@id": "niiri:height_threshold_id"
-        }, 
-        {
           "@id": "niiri:peak_definition_criteria_id"
-        }, 
-        {
-          "@id": "niiri:mask_id_1"
-        }, 
-        {
-          "@id": "niiri:cluster_definition_criteria_id"
         }, 
         {
           "@id": "niiri:extent_threshold_id"
         }, 
         {
           "@id": "niiri:resels_per_voxel_map_id"
+        }, 
+        {
+          "@id": "niiri:cluster_definition_criteria_id"
+        }, 
+        {
+          "@id": "niiri:mask_id_1"
+        }, 
+        {
+          "@id": "niiri:height_threshold_id"
+        }, 
+        {
+          "@id": "niiri:statistic_map_id"
         }
       ], 
       "prov:wasAssociatedWith": {
@@ -791,6 +804,12 @@
     }, 
     "StatisticMap": [
       {
+        "crypto:sha512": "55951f31f0ede7e88eca5cd4793df3f630aba21bc90fb81e3695db060c7d4c0b0ccf0b51fd8958c32ea3253d3122e9b31a54262bf910f8b5b646054ceb9a5825", 
+        "fileName": "spmT_0001.nii", 
+        "@id": "niiri:statistic_map_id_der", 
+        "format": "image/nifti"
+      }, 
+      {
         "prov:wasDerivedFrom": {
           "@id": "niiri:statistic_map_id_der"
         }, 
@@ -815,12 +834,6 @@
         "fileName": "TStatistic.nii.gz", 
         "effectDegreesOfFreedom": "1.0", 
         "@id": "niiri:statistic_map_id"
-      }, 
-      {
-        "crypto:sha512": "55951f31f0ede7e88eca5cd4793df3f630aba21bc90fb81e3695db060c7d4c0b0ccf0b51fd8958c32ea3253d3122e9b31a54262bf910f8b5b646054ceb9a5825", 
-        "fileName": "spmT_0001.nii", 
-        "@id": "niiri:statistic_map_id_der", 
-        "format": "image/nifti"
       }
     ], 
     "ContrastStandardErrorMap": {
@@ -843,21 +856,6 @@
     "prov:Person": {
       "@id": "niiri:subject_id", 
       "label": "Person"
-    }, 
-    "Statistic": {
-      "equivalentThreshold": [
-        {
-          "@id": "niiri:extent_threshold_id_3"
-        }, 
-        {
-          "@id": "niiri:extent_threshold_id_2"
-        }
-      ], 
-      "clusterSizeInVoxels": "0", 
-      "label": "Extent Threshold: k>=0", 
-      "clusterSizeInResels": "0.0", 
-      "@id": "niiri:extent_threshold_id", 
-      "@type": "ExtentThreshold"
     }, 
     "ClusterDefinitionCriteria": {
       "@id": "niiri:cluster_definition_criteria_id", 

--- a/nidm/nidm-results/spm/example002/spm_results_2contrasts.json
+++ b/nidm/nidm-results/spm/example002/spm_results_2contrasts.json
@@ -1,5 +1,5 @@
 {
-  "@context": "http://purl.org/nidash/context", 
+  "@context": "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/nidmr.json", 
   "@id": "file:///home/karl/Work/INCF/nidm/nidm/nidm/nidm-results/spm/example002/spm_results_2contrasts.ttl", 
   "records": {
     "PeakDefinitionCriteria": [
@@ -25,31 +25,31 @@
     "ConjunctionInference": {
       "prov:used": [
         {
+          "@id": "niiri:statistic_map_id"
+        }, 
+        {
           "@id": "niiri:statistic_map_id_2"
         }, 
         {
           "@id": "niiri:display_map_id_3"
         }, 
         {
-          "@id": "niiri:statistic_map_id"
+          "@id": "niiri:resels_per_voxel_map_id"
+        }, 
+        {
+          "@id": "niiri:mask_id_1"
         }, 
         {
           "@id": "niiri:height_threshold_id_3"
+        }, 
+        {
+          "@id": "niiri:peak_definition_criteria_id_3"
         }, 
         {
           "@id": "niiri:extent_threshold_id_3"
         }, 
         {
           "@id": "niiri:cluster_definition_criteria_id_3"
-        }, 
-        {
-          "@id": "niiri:peak_definition_criteria_id_3"
-        }, 
-        {
-          "@id": "niiri:mask_id_1"
-        }, 
-        {
-          "@id": "niiri:resels_per_voxel_map_id"
         }
       ], 
       "prov:wasAssociatedWith": {
@@ -136,19 +136,6 @@
         "prov:wasDerivedFrom": {
           "@id": "niiri:excursion_set_map_id"
         }, 
-        "pValueFWER": "0.00418900977249", 
-        "clusterSizeInVoxels": "12", 
-        "pValueUncorrected": "0.0818393184514", 
-        "qValueFDR": "0.0818393184514", 
-        "clusterSizeInResels": "0.0902882999012", 
-        "clusterLabelId": "5", 
-        "label": "Supra-Threshold Cluster: 0005", 
-        "@id": "niiri:supra_threshold_cluster_0005"
-      }, 
-      {
-        "prov:wasDerivedFrom": {
-          "@id": "niiri:excursion_set_map_id"
-        }, 
         "pValueFWER": "0.0", 
         "clusterSizeInVoxels": "839", 
         "pValueUncorrected": "3.5589682448e-19", 
@@ -157,6 +144,19 @@
         "clusterLabelId": "1", 
         "label": "Supra-Threshold Cluster: 0001", 
         "@id": "niiri:supra_threshold_cluster_0001"
+      }, 
+      {
+        "prov:wasDerivedFrom": {
+          "@id": "niiri:excursion_set_map_id"
+        }, 
+        "pValueFWER": "0.00418900977249", 
+        "clusterSizeInVoxels": "12", 
+        "pValueUncorrected": "0.0818393184514", 
+        "qValueFDR": "0.0818393184514", 
+        "clusterSizeInResels": "0.0902882999012", 
+        "clusterLabelId": "5", 
+        "label": "Supra-Threshold Cluster: 0005", 
+        "@id": "niiri:supra_threshold_cluster_0005"
       }, 
       {
         "prov:wasDerivedFrom": {
@@ -172,21 +172,24 @@
         "@id": "niiri:supra_threshold_cluster_0004"
       }
     ], 
-    "prov:SoftwareAgent": {
-      "softwareVersion": "12b.5853", 
-      "@id": "niiri:software_id", 
-      "@type": "SPM", 
-      "label": "SPM"
-    }, 
     "PValueUncorrected": [
       {
-        "@id": "niiri:height_threshold_id_13", 
-        "@type": "HeightThreshold", 
+        "@id": "niiri:extent_threshold_id_3_1", 
+        "@type": "ExtentThreshold", 
         "prov:value": {
           "@type": "xsd:float", 
-          "@value": "7.62276079258e-07"
+          "@value": "1.0"
         }, 
-        "label": "Height Threshold"
+        "label": "Extent Threshold"
+      }, 
+      {
+        "@id": "niiri:extent_threshold_id_33", 
+        "@type": "ExtentThreshold", 
+        "prov:value": {
+          "@type": "xsd:float", 
+          "@value": "1.0"
+        }, 
+        "label": "Extent Threshold"
       }, 
       {
         "@id": "niiri:extent_threshold_id_23", 
@@ -196,37 +199,11 @@
           "@value": "1.0"
         }, 
         "label": "Extent Threshold"
-      }, 
-      {
-        "equivalentThreshold": [
-          {
-            "@id": "niiri:height_threshold_id_33"
-          }, 
-          {
-            "@id": "niiri:height_threshold_id_32"
-          }
-        ], 
-        "@id": "niiri:height_threshold_id_3", 
-        "@type": "HeightThreshold", 
-        "prov:value": {
-          "@type": "xsd:float", 
-          "@value": "7.62276079258e-07"
-        }, 
-        "label": "Height Threshold: p<0.001 (unc)"
-      }, 
-      {
-        "@id": "niiri:height_threshold_id_3_2", 
-        "@type": "HeightThreshold", 
-        "prov:value": {
-          "@type": "xsd:float", 
-          "@value": "2.7772578457e-06"
-        }, 
-        "label": "Height Threshold"
       }
     ], 
     "FWERAdjustedPValue": [
       {
-        "@id": "niiri:extent_threshold_id_2_2", 
+        "@id": "niiri:extent_threshold_id_22", 
         "@type": "ExtentThreshold", 
         "prov:value": {
           "@type": "xsd:float", 
@@ -242,32 +219,24 @@
           "@value": "1.0"
         }, 
         "label": "Extent Threshold"
-      }, 
-      {
-        "equivalentThreshold": [
-          {
-            "@id": "niiri:height_threshold_id_3"
-          }, 
-          {
-            "@id": "niiri:height_threshold_id_2"
-          }
-        ], 
-        "@id": "niiri:height_threshold_id_1_2", 
-        "@type": "HeightThreshold", 
-        "prov:value": {
-          "@type": "xsd:float", 
-          "@value": "0.05"
-        }, 
-        "label": "Height Threshold: p<0.05 (FWE)"
       }
     ], 
     "HeightThreshold": [
       {
-        "@id": "niiri:height_threshold_id_2_2", 
+        "@id": "niiri:height_threshold_id_2_1", 
         "@type": "Statistic", 
         "prov:value": {
           "@type": "xsd:float", 
           "@value": "4.8524174569"
+        }, 
+        "label": "Height Threshold"
+      }, 
+      {
+        "@id": "niiri:height_threshold_id_13", 
+        "@type": "PValueUncorrected", 
+        "prov:value": {
+          "@type": "xsd:float", 
+          "@value": "7.62276079258e-07"
         }, 
         "label": "Height Threshold"
       }, 
@@ -289,15 +258,6 @@
         "label": "Height Threshold: p<0.05 (FWE)"
       }, 
       {
-        "@id": "niiri:height_threshold_id_22", 
-        "@type": "Statistic", 
-        "prov:value": {
-          "@type": "xsd:float", 
-          "@value": "5.23529984739"
-        }, 
-        "label": "Height Threshold"
-      }, 
-      {
         "@id": "niiri:height_threshold_id_23", 
         "@type": "FWERAdjustedPValue", 
         "prov:value": {
@@ -316,6 +276,32 @@
         "label": "Height Threshold"
       }, 
       {
+        "@id": "niiri:height_threshold_id_12", 
+        "@type": "Statistic", 
+        "prov:value": {
+          "@type": "xsd:float", 
+          "@value": "5.23529984739"
+        }, 
+        "label": "Height Threshold"
+      }, 
+      {
+        "equivalentThreshold": [
+          {
+            "@id": "niiri:height_threshold_id_32"
+          }, 
+          {
+            "@id": "niiri:height_threshold_id_33"
+          }
+        ], 
+        "@id": "niiri:height_threshold_id_3", 
+        "@type": "PValueUncorrected", 
+        "prov:value": {
+          "@type": "xsd:float", 
+          "@value": "7.62276079258e-07"
+        }, 
+        "label": "Height Threshold: p<0.001 (unc)"
+      }, 
+      {
         "equivalentThreshold": [
           {
             "@id": "niiri:height_threshold_id_2"
@@ -331,6 +317,32 @@
           "@value": "0.05"
         }, 
         "label": "Height Threshold: p<0.05 (FWE)"
+      }, 
+      {
+        "equivalentThreshold": [
+          {
+            "@id": "niiri:height_threshold_id_3"
+          }, 
+          {
+            "@id": "niiri:height_threshold_id_2"
+          }
+        ], 
+        "@id": "niiri:height_threshold_id_1_2", 
+        "@type": "FWERAdjustedPValue", 
+        "prov:value": {
+          "@type": "xsd:float", 
+          "@value": "0.05"
+        }, 
+        "label": "Height Threshold: p<0.05 (FWE)"
+      }, 
+      {
+        "@id": "niiri:height_threshold_id_3_2", 
+        "@type": "PValueUncorrected", 
+        "prov:value": {
+          "@type": "xsd:float", 
+          "@value": "2.7772578457e-06"
+        }, 
+        "label": "Height Threshold"
       }, 
       {
         "@id": "niiri:height_threshold_id_3_1", 
@@ -353,23 +365,8 @@
         "label": "Extent Threshold"
       }, 
       {
-        "equivalentThreshold": [
-          {
-            "@id": "niiri:height_threshold_id_13"
-          }, 
-          {
-            "@id": "niiri:height_threshold_id_12"
-          }
-        ], 
-        "clusterSizeInVoxels": "0", 
-        "label": "Extent Threshold: k>=0", 
-        "clusterSizeInResels": "0.0", 
-        "@id": "niiri:extent_threshold_id", 
-        "@type": "Statistic"
-      }, 
-      {
-        "@id": "niiri:extent_threshold_id_3_1", 
-        "@type": "PValueUncorrected", 
+        "@id": "niiri:extent_threshold_id_2_2", 
+        "@type": "FWERAdjustedPValue", 
         "prov:value": {
           "@type": "xsd:float", 
           "@value": "1.0"
@@ -395,22 +392,19 @@
         "label": "Extent Threshold"
       }, 
       {
-        "@id": "niiri:extent_threshold_id_33", 
-        "@type": "PValueUncorrected", 
-        "prov:value": {
-          "@type": "xsd:float", 
-          "@value": "1.0"
-        }, 
-        "label": "Extent Threshold"
-      }, 
-      {
-        "@id": "niiri:extent_threshold_id_22", 
-        "@type": "FWERAdjustedPValue", 
-        "prov:value": {
-          "@type": "xsd:float", 
-          "@value": "1.0"
-        }, 
-        "label": "Extent Threshold"
+        "equivalentThreshold": [
+          {
+            "@id": "niiri:extent_threshold_id_2"
+          }, 
+          {
+            "@id": "niiri:extent_threshold_id_3"
+          }
+        ], 
+        "clusterSizeInVoxels": "0", 
+        "label": "Extent Threshold: k>=0", 
+        "clusterSizeInResels": "0.0", 
+        "@id": "niiri:extent_threshold_id_1_1", 
+        "@type": "Statistic"
       }, 
       {
         "@id": "niiri:extent_threshold_id_13", 
@@ -507,7 +501,7 @@
         "@type": "xsd:dateTime", 
         "@value": "2014-05-19T10:30:00+01:00"
       }, 
-      "@id": "_:ff3e29136993346c19fe3b8ae0041a624b1", 
+      "@id": "_:f577eeb8581ef48359ab7c63cbcbf9fb3b1", 
       "prov:activity": {
         "@id": "niiri:export_id"
       }
@@ -537,80 +531,12 @@
       "fileName": "ExcursionSet.nii.gz", 
       "@id": "niiri:excursion_set_map_id"
     }, 
-    "Peak": [
-      {
-        "prov:wasDerivedFrom": {
-          "@id": "niiri:supra_threshold_cluster_0001"
-        }, 
-        "pValueFWER": "0.0", 
-        "equivalentZStatistic": "inf", 
-        "pValueUncorrected": "4.4408920985e-16", 
-        "qValueFDR": "1.19156591714e-11", 
-        "prov:value": {
-          "@type": "xsd:float", 
-          "@value": "17.5207633972"
-        }, 
-        "label": "Peak: 0001", 
-        "atLocation": {
-          "@id": "niiri:coordinate_0001"
-        }, 
-        "@id": "niiri:peak_0001"
-      }, 
-      {
-        "prov:wasDerivedFrom": {
-          "@id": "niiri:supra_threshold_cluster_0001"
-        }, 
-        "pValueFWER": "7.69451169447e-12", 
-        "equivalentZStatistic": "inf", 
-        "pValueUncorrected": "4.4408920985e-16", 
-        "qValueFDR": "6.84121260275e-10", 
-        "prov:value": {
-          "@type": "xsd:float", 
-          "@value": "10.2856016159"
-        }, 
-        "label": "Peak: 0003", 
-        "atLocation": {
-          "@id": "niiri:coordinate_0003"
-        }, 
-        "@id": "niiri:peak_0003"
-      }, 
-      {
-        "prov:wasDerivedFrom": {
-          "@id": "niiri:supra_threshold_cluster_0001"
-        }, 
-        "pValueFWER": "0.0", 
-        "equivalentZStatistic": "inf", 
-        "pValueUncorrected": "4.4408920985e-16", 
-        "qValueFDR": "1.19156591714e-11", 
-        "prov:value": {
-          "@type": "xsd:float", 
-          "@value": "13.0321407318"
-        }, 
-        "label": "Peak: 0002", 
-        "atLocation": {
-          "@id": "niiri:coordinate_0002"
-        }, 
-        "@id": "niiri:peak_0002"
-      }, 
-      {
-        "prov:wasDerivedFrom": {
-          "@id": "niiri:supra_threshold_cluster_0002"
-        }, 
-        "pValueFWER": "0.0", 
-        "equivalentZStatistic": "inf", 
-        "pValueUncorrected": "4.4408920985e-16", 
-        "qValueFDR": "1.19156591714e-11", 
-        "prov:value": {
-          "@type": "xsd:float", 
-          "@value": "13.5425577164"
-        }, 
-        "label": "Peak: 0004", 
-        "atLocation": {
-          "@id": "niiri:coordinate_0004"
-        }, 
-        "@id": "niiri:peak_0004"
-      }
-    ], 
+    "SPM": {
+      "softwareVersion": "12b.5853", 
+      "@id": "niiri:software_id", 
+      "@type": "prov:SoftwareAgent", 
+      "label": "SPM"
+    }, 
     "ResidualMeanSquaresMap": {
       "prov:wasGeneratedBy": {
         "@id": "niiri:model_pe_id"
@@ -635,22 +561,22 @@
         }, 
         "prov:used": [
           {
-            "@id": "niiri:design_matrix_id"
-          }, 
-          {
             "@id": "niiri:beta_map_id_1"
-          }, 
-          {
-            "@id": "niiri:contrast_id"
-          }, 
-          {
-            "@id": "niiri:mask_id_1"
           }, 
           {
             "@id": "niiri:residual_mean_squares_map_id"
           }, 
           {
             "@id": "niiri:beta_map_id_2"
+          }, 
+          {
+            "@id": "niiri:design_matrix_id"
+          }, 
+          {
+            "@id": "niiri:mask_id_1"
+          }, 
+          {
+            "@id": "niiri:contrast_id"
           }
         ], 
         "@id": "niiri:contrast_estimation_id", 
@@ -662,7 +588,7 @@
         }, 
         "prov:used": [
           {
-            "@id": "niiri:design_matrix_id"
+            "@id": "niiri:residual_mean_squares_map_id"
           }, 
           {
             "@id": "niiri:contrast_id_2"
@@ -671,10 +597,10 @@
             "@id": "niiri:beta_map_id_3"
           }, 
           {
-            "@id": "niiri:residual_mean_squares_map_id"
+            "@id": "niiri:mask_id_1"
           }, 
           {
-            "@id": "niiri:mask_id_1"
+            "@id": "niiri:design_matrix_id"
           }
         ], 
         "@id": "niiri:contrast_estimation_id_2", 
@@ -703,13 +629,13 @@
       }, 
       "prov:wasAttributedTo": [
         {
-          "@id": "niiri:group2_id"
+          "@id": "niiri:mr_scanner_id"
         }, 
         {
           "@id": "niiri:group_id"
         }, 
         {
-          "@id": "niiri:mr_scanner_id"
+          "@id": "niiri:group2_id"
         }
       ], 
       "targetIntensity": "100.0", 
@@ -752,21 +678,16 @@
       "@id": "niiri:export_id", 
       "label": "NIDM-Results export"
     }, 
-    "Magnetic resonance imaging scanner": {
-      "@id": "niiri:mr_scanner_id", 
-      "@type": "Imaging instrument", 
-      "label": "MRI Scanner"
-    }, 
     "ModelParameterEstimation": {
       "prov:used": [
         {
           "@id": "niiri:data_id"
         }, 
         {
-          "@id": "niiri:design_matrix_id"
+          "@id": "niiri:error_model_id"
         }, 
         {
-          "@id": "niiri:error_model_id"
+          "@id": "niiri:design_matrix_id"
         }
       ], 
       "prov:wasAssociatedWith": {
@@ -851,9 +772,14 @@
       "@id": "niiri:design_matrix_png_id", 
       "format": "image/png"
     }, 
+    "Imaging instrument": {
+      "@id": "niiri:mr_scanner_id", 
+      "@type": "Magnetic resonance imaging scanner", 
+      "label": "MRI Scanner"
+    }, 
     "NIDMResults": {
       "prov:qualifiedGeneration": {
-        "@id": "_:ff3e29136993346c19fe3b8ae0041a624b1"
+        "@id": "_:f577eeb8581ef48359ab7c63cbcbf9fb3b1"
       }, 
       "version": "1.3.0", 
       "@id": "niiri:spm_results_id", 
@@ -954,22 +880,22 @@
       {
         "prov:used": [
           {
+            "@id": "niiri:statistic_map_id"
+          }, 
+          {
+            "@id": "niiri:extent_threshold_id_1_1"
+          }, 
+          {
             "@id": "niiri:mask_id_1"
           }, 
           {
             "@id": "niiri:peak_definition_criteria_id"
           }, 
           {
-            "@id": "niiri:extent_threshold_id_1_1"
-          }, 
-          {
-            "@id": "niiri:statistic_map_id"
+            "@id": "niiri:cluster_definition_criteria_id"
           }, 
           {
             "@id": "niiri:height_threshold_id_1_1"
-          }, 
-          {
-            "@id": "niiri:cluster_definition_criteria_id"
           }, 
           {
             "@id": "niiri:resels_per_voxel_map_id"
@@ -987,25 +913,25 @@
       {
         "prov:used": [
           {
+            "@id": "niiri:extent_threshold_id_1_2"
+          }, 
+          {
             "@id": "niiri:cluster_definition_criteria_id_2"
-          }, 
-          {
-            "@id": "niiri:resels_per_voxel_map_id"
-          }, 
-          {
-            "@id": "niiri:height_threshold_id_1_2"
-          }, 
-          {
-            "@id": "niiri:statistic_map_id_2"
           }, 
           {
             "@id": "niiri:peak_definition_criteria_id_2"
           }, 
           {
-            "@id": "niiri:extent_threshold_id_1_2"
+            "@id": "niiri:mask_id_1"
           }, 
           {
-            "@id": "niiri:mask_id_1"
+            "@id": "niiri:height_threshold_id_1_2"
+          }, 
+          {
+            "@id": "niiri:resels_per_voxel_map_id"
+          }, 
+          {
+            "@id": "niiri:statistic_map_id_2"
           }
         ], 
         "prov:wasAssociatedWith": {
@@ -1046,12 +972,6 @@
         "@id": "niiri:statistic_map_id_2"
       }, 
       {
-        "crypto:sha512": "e43b6e01b0463fe7d40782137867a", 
-        "fileName": "spmT_0002.nii", 
-        "@id": "niiri:statistic_map_id_2_der", 
-        "format": "image/nifti"
-      }, 
-      {
         "prov:wasDerivedFrom": {
           "@id": "niiri:statistic_map_id_der"
         }, 
@@ -1076,6 +996,12 @@
         "fileName": "TStatistic_0001.nii.gz", 
         "effectDegreesOfFreedom": "1.0", 
         "@id": "niiri:statistic_map_id"
+      }, 
+      {
+        "crypto:sha512": "e43b6e01b0463fe7d40782137867a", 
+        "fileName": "spmT_0002.nii", 
+        "@id": "niiri:statistic_map_id_2_der", 
+        "format": "image/nifti"
       }, 
       {
         "crypto:sha512": "e43b6e01b0463fe7d40782137867a", 
@@ -1140,11 +1066,35 @@
     }, 
     "Statistic": [
       {
-        "@id": "niiri:height_threshold_id_2_1", 
+        "equivalentThreshold": [
+          {
+            "@id": "niiri:height_threshold_id_12"
+          }, 
+          {
+            "@id": "niiri:height_threshold_id_13"
+          }
+        ], 
+        "clusterSizeInVoxels": "0", 
+        "label": "Extent Threshold: k>=0", 
+        "clusterSizeInResels": "0.0", 
+        "@id": "niiri:extent_threshold_id", 
+        "@type": "ExtentThreshold"
+      }, 
+      {
+        "@id": "niiri:height_threshold_id_2_2", 
         "@type": "HeightThreshold", 
         "prov:value": {
           "@type": "xsd:float", 
           "@value": "4.8524174569"
+        }, 
+        "label": "Height Threshold"
+      }, 
+      {
+        "@id": "niiri:height_threshold_id_22", 
+        "@type": "HeightThreshold", 
+        "prov:value": {
+          "@type": "xsd:float", 
+          "@value": "5.23529984739"
         }, 
         "label": "Height Threshold"
       }, 
@@ -1164,21 +1114,6 @@
         "@type": "ExtentThreshold"
       }, 
       {
-        "equivalentThreshold": [
-          {
-            "@id": "niiri:extent_threshold_id_2"
-          }, 
-          {
-            "@id": "niiri:extent_threshold_id_3"
-          }
-        ], 
-        "clusterSizeInVoxels": "0", 
-        "label": "Extent Threshold: k>=0", 
-        "clusterSizeInResels": "0.0", 
-        "@id": "niiri:extent_threshold_id_1_1", 
-        "@type": "ExtentThreshold"
-      }, 
-      {
         "@id": "niiri:height_threshold_id_32", 
         "@type": "HeightThreshold", 
         "prov:value": {
@@ -1190,10 +1125,10 @@
       {
         "equivalentThreshold": [
           {
-            "@id": "niiri:height_threshold_id_12"
+            "@id": "niiri:height_threshold_id_13"
           }, 
           {
-            "@id": "niiri:height_threshold_id_13"
+            "@id": "niiri:height_threshold_id_12"
           }
         ], 
         "clusterSizeInVoxels": "10", 
@@ -1201,15 +1136,80 @@
         "clusterSizeInResels": "3.3", 
         "@id": "niiri:extent_threshold_id_3", 
         "@type": "ExtentThreshold"
-      }, 
+      }
+    ], 
+    "Peak": [
       {
-        "@id": "niiri:height_threshold_id_12", 
-        "@type": "HeightThreshold", 
+        "prov:wasDerivedFrom": {
+          "@id": "niiri:supra_threshold_cluster_0001"
+        }, 
+        "pValueFWER": "0.0", 
+        "equivalentZStatistic": "inf", 
+        "pValueUncorrected": "4.4408920985e-16", 
+        "qValueFDR": "1.19156591714e-11", 
         "prov:value": {
           "@type": "xsd:float", 
-          "@value": "5.23529984739"
+          "@value": "17.5207633972"
         }, 
-        "label": "Height Threshold"
+        "label": "Peak: 0001", 
+        "atLocation": {
+          "@id": "niiri:coordinate_0001"
+        }, 
+        "@id": "niiri:peak_0001"
+      }, 
+      {
+        "prov:wasDerivedFrom": {
+          "@id": "niiri:supra_threshold_cluster_0001"
+        }, 
+        "pValueFWER": "7.69451169447e-12", 
+        "equivalentZStatistic": "inf", 
+        "pValueUncorrected": "4.4408920985e-16", 
+        "qValueFDR": "6.84121260275e-10", 
+        "prov:value": {
+          "@type": "xsd:float", 
+          "@value": "10.2856016159"
+        }, 
+        "label": "Peak: 0003", 
+        "atLocation": {
+          "@id": "niiri:coordinate_0003"
+        }, 
+        "@id": "niiri:peak_0003"
+      }, 
+      {
+        "prov:wasDerivedFrom": {
+          "@id": "niiri:supra_threshold_cluster_0001"
+        }, 
+        "pValueFWER": "0.0", 
+        "equivalentZStatistic": "inf", 
+        "pValueUncorrected": "4.4408920985e-16", 
+        "qValueFDR": "1.19156591714e-11", 
+        "prov:value": {
+          "@type": "xsd:float", 
+          "@value": "13.0321407318"
+        }, 
+        "label": "Peak: 0002", 
+        "atLocation": {
+          "@id": "niiri:coordinate_0002"
+        }, 
+        "@id": "niiri:peak_0002"
+      }, 
+      {
+        "prov:wasDerivedFrom": {
+          "@id": "niiri:supra_threshold_cluster_0002"
+        }, 
+        "pValueFWER": "0.0", 
+        "equivalentZStatistic": "inf", 
+        "pValueUncorrected": "4.4408920985e-16", 
+        "qValueFDR": "1.19156591714e-11", 
+        "prov:value": {
+          "@type": "xsd:float", 
+          "@value": "13.5425577164"
+        }, 
+        "label": "Peak: 0004", 
+        "atLocation": {
+          "@id": "niiri:coordinate_0004"
+        }, 
+        "@id": "niiri:peak_0004"
       }
     ], 
     "ClusterDefinitionCriteria": [

--- a/nidm/nidm-results/spm/example003/spm_results_conjunction.json
+++ b/nidm/nidm-results/spm/example003/spm_results_conjunction.json
@@ -1,5 +1,5 @@
 {
-  "@context": "http://purl.org/nidash/context", 
+  "@context": "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/nidmr.json", 
   "@id": "file:///home/karl/Work/INCF/nidm/nidm/nidm/nidm-results/spm/example003/spm_results_conjunction.ttl", 
   "records": {
     "PeakDefinitionCriteria": {
@@ -11,31 +11,31 @@
     "ConjunctionInference": {
       "prov:used": [
         {
-          "@id": "niiri:peak_definition_criteria_id"
-        }, 
-        {
-          "@id": "niiri:statistic_map_id"
-        }, 
-        {
-          "@id": "niiri:statistic_map_id_2"
-        }, 
-        {
           "@id": "niiri:cluster_definition_criteria_id"
         }, 
         {
           "@id": "niiri:height_threshold_id"
         }, 
         {
+          "@id": "niiri:display_map_id"
+        }, 
+        {
+          "@id": "niiri:statistic_map_id"
+        }, 
+        {
           "@id": "niiri:resels_per_voxel_map_id"
+        }, 
+        {
+          "@id": "niiri:statistic_map_id_2"
+        }, 
+        {
+          "@id": "niiri:extent_threshold_id"
         }, 
         {
           "@id": "niiri:mask_id_1"
         }, 
         {
-          "@id": "niiri:display_map_id"
-        }, 
-        {
-          "@id": "niiri:extent_threshold_id"
+          "@id": "niiri:peak_definition_criteria_id"
         }
       ], 
       "prov:wasAssociatedWith": {
@@ -47,29 +47,24 @@
         "@id": "nidm:NIDM_0000060"
       }
     }, 
-    "HeightThreshold": {
-      "@id": "niiri:height_threshold_id_3", 
-      "@type": "FWERAdjustedPValue", 
-      "prov:value": {
-        "@type": "xsd:float", 
-        "@value": "0.05"
+    "DesignMatrix": {
+      "description": {
+        "@id": "niiri:design_matrix_png_id"
       }, 
-      "label": "Height Threshold"
+      "format": "text/csv", 
+      "label": "Design Matrix", 
+      "atLocation": {
+        "@type": "xsd:anyURI", 
+        "@value": "DesignMatrix.csv"
+      }, 
+      "fileName": "DesignMatrix.csv", 
+      "@id": "niiri:design_matrix_id"
     }, 
-    "StudyGroupPopulation": [
-      {
-        "groupName": "Control", 
-        "label": "Group: Control", 
-        "@id": "niiri:group_id", 
-        "numberOfSubjects": "23"
-      }, 
-      {
-        "groupName": "Patient", 
-        "label": "Group: Patient", 
-        "@id": "niiri:group2_id", 
-        "numberOfSubjects": "21"
-      }
-    ], 
+    "spm": {
+      "softwareVersion": "12b.5858", 
+      "@id": "niiri:exporter_id", 
+      "label": "spm_results_nidm"
+    }, 
     "ParameterEstimateMap": [
       {
         "prov:wasDerivedFrom": {
@@ -155,6 +150,19 @@
         "prov:wasDerivedFrom": {
           "@id": "niiri:excursion_set_map_id"
         }, 
+        "pValueFWER": "0.0", 
+        "clusterSizeInVoxels": "839", 
+        "pValueUncorrected": "3.5589682448e-19", 
+        "qValueFDR": "1.7794841224e-18", 
+        "clusterSizeInResels": "6.31265696809", 
+        "clusterLabelId": "1", 
+        "label": "Supra-Threshold Cluster: 0001", 
+        "@id": "niiri:supra_threshold_cluster_0001"
+      }, 
+      {
+        "prov:wasDerivedFrom": {
+          "@id": "niiri:excursion_set_map_id"
+        }, 
         "pValueFWER": "0.00418900977249", 
         "clusterSizeInVoxels": "12", 
         "pValueUncorrected": "0.0818393184514", 
@@ -163,6 +171,19 @@
         "clusterLabelId": "5", 
         "label": "Supra-Threshold Cluster: 0005", 
         "@id": "niiri:supra_threshold_cluster_0005"
+      }, 
+      {
+        "prov:wasDerivedFrom": {
+          "@id": "niiri:excursion_set_map_id"
+        }, 
+        "pValueFWER": "0.000565384750378", 
+        "clusterSizeInVoxels": "29", 
+        "pValueUncorrected": "0.0110257032105", 
+        "qValueFDR": "0.0137821290131", 
+        "clusterSizeInResels": "0.218196724761", 
+        "clusterLabelId": "4", 
+        "label": "Supra-Threshold Cluster: 0004", 
+        "@id": "niiri:supra_threshold_cluster_0004"
       }, 
       {
         "prov:wasDerivedFrom": {
@@ -189,47 +210,15 @@
         "clusterLabelId": "2", 
         "label": "Supra-Threshold Cluster: 0002", 
         "@id": "niiri:supra_threshold_cluster_0002"
-      }, 
-      {
-        "prov:wasDerivedFrom": {
-          "@id": "niiri:excursion_set_map_id"
-        }, 
-        "pValueFWER": "0.000565384750378", 
-        "clusterSizeInVoxels": "29", 
-        "pValueUncorrected": "0.0110257032105", 
-        "qValueFDR": "0.0137821290131", 
-        "clusterSizeInResels": "0.218196724761", 
-        "clusterLabelId": "4", 
-        "label": "Supra-Threshold Cluster: 0004", 
-        "@id": "niiri:supra_threshold_cluster_0004"
-      }, 
-      {
-        "prov:wasDerivedFrom": {
-          "@id": "niiri:excursion_set_map_id"
-        }, 
-        "pValueFWER": "0.0", 
-        "clusterSizeInVoxels": "839", 
-        "pValueUncorrected": "3.5589682448e-19", 
-        "qValueFDR": "1.7794841224e-18", 
-        "clusterSizeInResels": "6.31265696809", 
-        "clusterLabelId": "1", 
-        "label": "Supra-Threshold Cluster: 0001", 
-        "@id": "niiri:supra_threshold_cluster_0001"
       }
     ], 
-    "prov:SoftwareAgent": {
-      "softwareVersion": "12b.5853", 
-      "@id": "niiri:software_id", 
-      "@type": "SPM", 
-      "label": "SPM"
-    }, 
     "PValueUncorrected": {
       "equivalentThreshold": [
         {
-          "@id": "niiri:height_threshold_id_3"
+          "@id": "niiri:height_threshold_id_2"
         }, 
         {
-          "@id": "niiri:height_threshold_id_2"
+          "@id": "niiri:height_threshold_id_3"
         }
       ], 
       "@id": "niiri:height_threshold_id", 
@@ -240,6 +229,26 @@
       }, 
       "label": "Height Threshold: p<7.62276079258051e-07 (unc)"
     }, 
+    "FWERAdjustedPValue": [
+      {
+        "@id": "niiri:extent_threshold_id_2", 
+        "@type": "ExtentThreshold", 
+        "prov:value": {
+          "@type": "xsd:float", 
+          "@value": "1.0"
+        }, 
+        "label": "Extent Threshold"
+      }, 
+      {
+        "@id": "niiri:height_threshold_id_3", 
+        "@type": "HeightThreshold", 
+        "prov:value": {
+          "@type": "xsd:float", 
+          "@value": "0.05"
+        }, 
+        "label": "Height Threshold"
+      }
+    ], 
     "MaskMap": {
       "prov:wasGeneratedBy": {
         "@id": "niiri:model_pe_id"
@@ -260,13 +269,19 @@
     }, 
     "ExtentThreshold": [
       {
-        "@id": "niiri:extent_threshold_id_2", 
-        "@type": "FWERAdjustedPValue", 
-        "prov:value": {
-          "@type": "xsd:float", 
-          "@value": "1.0"
-        }, 
-        "label": "Extent Threshold"
+        "equivalentThreshold": [
+          {
+            "@id": "niiri:height_threshold_id_2"
+          }, 
+          {
+            "@id": "niiri:height_threshold_id_3"
+          }
+        ], 
+        "clusterSizeInVoxels": "10", 
+        "label": "Extent Threshold: k>=10", 
+        "clusterSizeInResels": "3.3", 
+        "@id": "niiri:extent_threshold_id", 
+        "@type": "Statistic"
       }, 
       {
         "@id": "niiri:extent_threshold_id_3", 
@@ -295,7 +310,7 @@
         "@type": "xsd:dateTime", 
         "@value": "2014-05-19T10:30:00+01:00"
       }, 
-      "@id": "_:fb818debf62d64bae831d4cee1626239ab1", 
+      "@id": "_:fc07b9f9cab1d4b67ba91824f6ca0fd82b1", 
       "prov:activity": {
         "@id": "niiri:export_id"
       }
@@ -336,24 +351,6 @@
         "qValueFDR": "1.19156591714e-11", 
         "prov:value": {
           "@type": "xsd:float", 
-          "@value": "13.0321407318"
-        }, 
-        "label": "Peak: 0002", 
-        "atLocation": {
-          "@id": "niiri:coordinate_0002"
-        }, 
-        "@id": "niiri:peak_0002"
-      }, 
-      {
-        "prov:wasDerivedFrom": {
-          "@id": "niiri:supra_threshold_cluster_0001"
-        }, 
-        "pValueFWER": "0.0", 
-        "equivalentZStatistic": "inf", 
-        "pValueUncorrected": "4.4408920985e-16", 
-        "qValueFDR": "1.19156591714e-11", 
-        "prov:value": {
-          "@type": "xsd:float", 
           "@value": "17.5207633972"
         }, 
         "label": "Peak: 0001", 
@@ -379,6 +376,24 @@
           "@id": "niiri:coordinate_0003"
         }, 
         "@id": "niiri:peak_0003"
+      }, 
+      {
+        "prov:wasDerivedFrom": {
+          "@id": "niiri:supra_threshold_cluster_0001"
+        }, 
+        "pValueFWER": "0.0", 
+        "equivalentZStatistic": "inf", 
+        "pValueUncorrected": "4.4408920985e-16", 
+        "qValueFDR": "1.19156591714e-11", 
+        "prov:value": {
+          "@type": "xsd:float", 
+          "@value": "13.0321407318"
+        }, 
+        "label": "Peak: 0002", 
+        "atLocation": {
+          "@id": "niiri:coordinate_0002"
+        }, 
+        "@id": "niiri:peak_0002"
       }, 
       {
         "prov:wasDerivedFrom": {
@@ -420,23 +435,26 @@
         }, 
         "prov:used": [
           {
-            "@id": "niiri:design_matrix_id"
-          }, 
-          {
-            "@id": "niiri:contrast_id_2"
-          }, 
-          {
             "@id": "niiri:mask_id_1"
           }, 
           {
-            "@id": "niiri:beta_map_id_3"
+            "@id": "niiri:design_matrix_id"
           }, 
           {
             "@id": "niiri:residual_mean_squares_map_id"
+          }, 
+          {
+            "@id": "niiri:contrast_id"
+          }, 
+          {
+            "@id": "niiri:beta_map_id_1"
+          }, 
+          {
+            "@id": "niiri:beta_map_id_2"
           }
         ], 
-        "@id": "niiri:contrast_estimation_id_2", 
-        "label": "Contrast estimation 2"
+        "@id": "niiri:contrast_estimation_id", 
+        "label": "Contrast estimation 1"
       }, 
       {
         "prov:wasAssociatedWith": {
@@ -444,26 +462,23 @@
         }, 
         "prov:used": [
           {
-            "@id": "niiri:beta_map_id_2"
-          }, 
-          {
-            "@id": "niiri:beta_map_id_1"
-          }, 
-          {
             "@id": "niiri:design_matrix_id"
           }, 
           {
             "@id": "niiri:residual_mean_squares_map_id"
           }, 
           {
+            "@id": "niiri:beta_map_id_3"
+          }, 
+          {
             "@id": "niiri:mask_id_1"
           }, 
           {
-            "@id": "niiri:contrast_id"
+            "@id": "niiri:contrast_id_2"
           }
         ], 
-        "@id": "niiri:contrast_estimation_id", 
-        "label": "Contrast estimation 1"
+        "@id": "niiri:contrast_estimation_id_2", 
+        "label": "Contrast estimation 2"
       }
     ], 
     "ErrorModel": {
@@ -488,19 +503,25 @@
       }, 
       "prov:wasAttributedTo": [
         {
+          "@id": "niiri:group2_id"
+        }, 
+        {
           "@id": "niiri:mr_scanner_id"
         }, 
         {
           "@id": "niiri:group_id"
-        }, 
-        {
-          "@id": "niiri:group2_id"
         }
       ], 
       "targetIntensity": "100.0", 
       "grandMeanScaling": true, 
       "label": "Data", 
       "@id": "niiri:data_id"
+    }, 
+    "SPM": {
+      "softwareVersion": "12b.5853", 
+      "@id": "niiri:software_id", 
+      "@type": "prov:SoftwareAgent", 
+      "label": "SPM"
     }, 
     "ReselsPerVoxelMap": [
       {
@@ -540,13 +561,13 @@
     "ModelParameterEstimation": {
       "prov:used": [
         {
-          "@id": "niiri:design_matrix_id"
-        }, 
-        {
           "@id": "niiri:data_id"
         }, 
         {
           "@id": "niiri:error_model_id"
+        }, 
+        {
+          "@id": "niiri:design_matrix_id"
         }
       ], 
       "prov:wasAssociatedWith": {
@@ -622,24 +643,11 @@
     }, 
     "NIDMResults": {
       "prov:qualifiedGeneration": {
-        "@id": "_:fb818debf62d64bae831d4cee1626239ab1"
+        "@id": "_:fc07b9f9cab1d4b67ba91824f6ca0fd82b1"
       }, 
       "version": "1.3.0", 
       "@id": "niiri:spm_results_id", 
       "label": "NIDM-Results"
-    }, 
-    "DesignMatrix": {
-      "description": {
-        "@id": "niiri:design_matrix_png_id"
-      }, 
-      "format": "text/csv", 
-      "label": "Design Matrix", 
-      "atLocation": {
-        "@type": "xsd:anyURI", 
-        "@value": "DesignMatrix.csv"
-      }, 
-      "fileName": "DesignMatrix.csv", 
-      "@id": "niiri:design_matrix_id"
     }, 
     "Coordinate": [
       {
@@ -664,27 +672,6 @@
       }
     ], 
     "ContrastMap": [
-      {
-        "prov:wasDerivedFrom": {
-          "@id": "niiri:contrast_map_id_der"
-        }, 
-        "prov:wasGeneratedBy": {
-          "@id": "niiri:contrast_estimation_id"
-        }, 
-        "format": "image/nifti", 
-        "inCoordinateSpace": {
-          "@id": "niiri:coordinate_space_id_1"
-        }, 
-        "label": "Contrast Map: listening > reading", 
-        "contrastName": "listening > reading", 
-        "atLocation": {
-          "@type": "xsd:anyURI", 
-          "@value": "Contrast_0001.nii.gz"
-        }, 
-        "crypto:sha512": "e43b6e01b0463fe7d40782137867a", 
-        "fileName": "Contrast_0001.nii.gz", 
-        "@id": "niiri:contrast_map_id"
-      }, 
       {
         "crypto:sha512": "e43b6e01b0463fe7d40782137867a", 
         "fileName": "con_0001.nii", 
@@ -717,6 +704,27 @@
         "crypto:sha512": "e43b6e01b0463fe7d40782137867a", 
         "fileName": "Contrast_0002.nii.gz", 
         "@id": "niiri:contrast_map_id_2"
+      }, 
+      {
+        "prov:wasDerivedFrom": {
+          "@id": "niiri:contrast_map_id_der"
+        }, 
+        "prov:wasGeneratedBy": {
+          "@id": "niiri:contrast_estimation_id"
+        }, 
+        "format": "image/nifti", 
+        "inCoordinateSpace": {
+          "@id": "niiri:coordinate_space_id_1"
+        }, 
+        "label": "Contrast Map: listening > reading", 
+        "contrastName": "listening > reading", 
+        "atLocation": {
+          "@type": "xsd:anyURI", 
+          "@value": "Contrast_0001.nii.gz"
+        }, 
+        "crypto:sha512": "e43b6e01b0463fe7d40782137867a", 
+        "fileName": "Contrast_0001.nii.gz", 
+        "@id": "niiri:contrast_map_id"
       }
     ], 
     "ClusterLabelsMap": {
@@ -762,12 +770,6 @@
       }, 
       {
         "crypto:sha512": "e43b6e01b0463fe7d40782137867a", 
-        "fileName": "spmT_0002.nii", 
-        "@id": "niiri:statistic_map_id_2_der", 
-        "format": "image/nifti"
-      }, 
-      {
-        "crypto:sha512": "e43b6e01b0463fe7d40782137867a", 
         "fileName": "spmT_0001.nii", 
         "@id": "niiri:statistic_map_id_der", 
         "format": "image/nifti"
@@ -797,26 +799,15 @@
         "fileName": "TStatistic_0002.nii.gz", 
         "effectDegreesOfFreedom": "1.0", 
         "@id": "niiri:statistic_map_id_2"
+      }, 
+      {
+        "crypto:sha512": "e43b6e01b0463fe7d40782137867a", 
+        "fileName": "spmT_0002.nii", 
+        "@id": "niiri:statistic_map_id_2_der", 
+        "format": "image/nifti"
       }
     ], 
     "ContrastStandardErrorMap": [
-      {
-        "prov:wasGeneratedBy": {
-          "@id": "niiri:contrast_estimation_id"
-        }, 
-        "format": "image/nifti", 
-        "inCoordinateSpace": {
-          "@id": "niiri:coordinate_space_id_1"
-        }, 
-        "fileName": "ContrastStandardError_0001.nii.gz", 
-        "atLocation": {
-          "@type": "xsd:anyURI", 
-          "@value": "ContrastStandardError_0001.nii.gz"
-        }, 
-        "crypto:sha512": "e43b6e01b0463fe7d40782137867a", 
-        "label": "Contrast 1 Standard Error Map", 
-        "@id": "niiri:contrast_standard_error_map_id"
-      }, 
       {
         "prov:wasGeneratedBy": {
           "@id": "niiri:contrast_estimation_id_2"
@@ -833,6 +824,23 @@
         "crypto:sha512": "e43b6e01b0463fe7d40782137867a", 
         "label": "Contrast 2 Standard Error Map", 
         "@id": "niiri:contrast_standard_error_map_id_2"
+      }, 
+      {
+        "prov:wasGeneratedBy": {
+          "@id": "niiri:contrast_estimation_id"
+        }, 
+        "format": "image/nifti", 
+        "inCoordinateSpace": {
+          "@id": "niiri:coordinate_space_id_1"
+        }, 
+        "fileName": "ContrastStandardError_0001.nii.gz", 
+        "atLocation": {
+          "@type": "xsd:anyURI", 
+          "@value": "ContrastStandardError_0001.nii.gz"
+        }, 
+        "crypto:sha512": "e43b6e01b0463fe7d40782137867a", 
+        "label": "Contrast 1 Standard Error Map", 
+        "@id": "niiri:contrast_standard_error_map_id"
       }
     ], 
     "GrandMeanMap": {
@@ -853,32 +861,15 @@
       "label": "Grand Mean Map", 
       "@id": "niiri:grand_mean_map_id"
     }, 
-    "Statistic": [
-      {
-        "equivalentThreshold": [
-          {
-            "@id": "niiri:height_threshold_id_2"
-          }, 
-          {
-            "@id": "niiri:height_threshold_id_3"
-          }
-        ], 
-        "clusterSizeInVoxels": "10", 
-        "label": "Extent Threshold: k>=10", 
-        "clusterSizeInResels": "3.3", 
-        "@id": "niiri:extent_threshold_id", 
-        "@type": "ExtentThreshold"
+    "Statistic": {
+      "@id": "niiri:height_threshold_id_2", 
+      "@type": "HeightThreshold", 
+      "prov:value": {
+        "@type": "xsd:float", 
+        "@value": "5.23529984739"
       }, 
-      {
-        "@id": "niiri:height_threshold_id_2", 
-        "@type": "HeightThreshold", 
-        "prov:value": {
-          "@type": "xsd:float", 
-          "@value": "5.23529984739"
-        }, 
-        "label": "Height Threshold"
-      }
-    ], 
+      "label": "Height Threshold"
+    }, 
     "ClusterDefinitionCriteria": {
       "@id": "niiri:cluster_definition_criteria_id", 
       "hasConnectivityCriterion": {
@@ -917,10 +908,19 @@
       }, 
       "searchVolumeInUnits": "1871262.0"
     }, 
-    "spm": {
-      "softwareVersion": "12b.5858", 
-      "@id": "niiri:exporter_id", 
-      "label": "spm_results_nidm"
-    }
+    "StudyGroupPopulation": [
+      {
+        "groupName": "Patient", 
+        "label": "Group: Patient", 
+        "@id": "niiri:group2_id", 
+        "numberOfSubjects": "21"
+      }, 
+      {
+        "groupName": "Control", 
+        "label": "Group: Control", 
+        "@id": "niiri:group_id", 
+        "numberOfSubjects": "23"
+      }
+    ]
   }
 }

--- a/nidm/nidm-results/spm/spm_results.json
+++ b/nidm/nidm-results/spm/spm_results.json
@@ -1,5 +1,5 @@
 {
-  "@context": "http://purl.org/nidash/context", 
+  "@context": "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/nidmr.json", 
   "@id": "file:///home/karl/Work/INCF/nidm/nidm/nidm/nidm-results/spm/spm_results.ttl", 
   "records": {
     "PeakDefinitionCriteria": {
@@ -22,26 +22,34 @@
       "@id": "niiri:design_matrix_id"
     }, 
     "HeightThreshold": {
-      "@id": "niiri:height_threshold_id_3", 
-      "@type": "PValueUncorrected", 
+      "equivalentThreshold": [
+        {
+          "@id": "niiri:height_threshold_id_3"
+        }, 
+        {
+          "@id": "niiri:height_threshold_id_2"
+        }
+      ], 
+      "@id": "niiri:height_threshold_id", 
+      "@type": "FWERAdjustedPValue", 
       "prov:value": {
         "@type": "xsd:float", 
-        "@value": "7.62276079258e-07"
+        "@value": "0.05"
       }, 
-      "label": "Height Threshold: p<7.62276079258051e-07 (uncorrected)"
+      "label": "Height Threshold: p<0.05 (FWE)"
     }, 
     "StudyGroupPopulation": [
-      {
-        "groupName": "Patient", 
-        "label": "Group: Patient", 
-        "@id": "niiri:group2_id", 
-        "numberOfSubjects": "21"
-      }, 
       {
         "groupName": "Control", 
         "label": "Group: Control", 
         "@id": "niiri:group_id", 
         "numberOfSubjects": "23"
+      }, 
+      {
+        "groupName": "Patient", 
+        "label": "Group: Patient", 
+        "@id": "niiri:group2_id", 
+        "numberOfSubjects": "21"
       }
     ], 
     "ParameterEstimateMap": [
@@ -145,37 +153,23 @@
         "@id": "niiri:supra_threshold_cluster_0002"
       }
     ], 
-    "prov:SoftwareAgent": {
-      "softwareVersion": "12b.5853", 
-      "@id": "niiri:software_id", 
-      "@type": "SPM", 
-      "label": "SPM"
-    }, 
     "PValueUncorrected": {
-      "@id": "niiri:extent_threshold_id_3", 
+      "@id": "niiri:height_threshold_id_3", 
+      "@type": "HeightThreshold", 
+      "prov:value": {
+        "@type": "xsd:float", 
+        "@value": "7.62276079258e-07"
+      }, 
+      "label": "Height Threshold: p<7.62276079258051e-07 (uncorrected)"
+    }, 
+    "FWERAdjustedPValue": {
+      "@id": "niiri:extent_threshold_id_2", 
       "@type": "ExtentThreshold", 
       "prov:value": {
         "@type": "xsd:float", 
         "@value": "1.0"
       }, 
       "label": "Extent Threshold"
-    }, 
-    "FWERAdjustedPValue": {
-      "equivalentThreshold": [
-        {
-          "@id": "niiri:height_threshold_id_2"
-        }, 
-        {
-          "@id": "niiri:height_threshold_id_3"
-        }
-      ], 
-      "@id": "niiri:height_threshold_id", 
-      "@type": "HeightThreshold", 
-      "prov:value": {
-        "@type": "xsd:float", 
-        "@value": "0.05"
-      }, 
-      "label": "Height Threshold: p<0.05 (FWE)"
     }, 
     "MaskMap": [
       {
@@ -248,15 +242,32 @@
         "@id": "niiri:mask_id_3"
       }
     ], 
-    "ExtentThreshold": {
-      "@id": "niiri:extent_threshold_id_2", 
-      "@type": "FWERAdjustedPValue", 
-      "prov:value": {
-        "@type": "xsd:float", 
-        "@value": "1.0"
+    "ExtentThreshold": [
+      {
+        "equivalentThreshold": [
+          {
+            "@id": "niiri:height_threshold_id_2"
+          }, 
+          {
+            "@id": "niiri:height_threshold_id_3"
+          }
+        ], 
+        "clusterSizeInVoxels": "0", 
+        "label": "Extent Threshold: k>=0", 
+        "clusterSizeInResels": "0.0", 
+        "@id": "niiri:extent_threshold_id", 
+        "@type": "Statistic"
       }, 
-      "label": "Extent Threshold"
-    }, 
+      {
+        "@id": "niiri:extent_threshold_id_3", 
+        "@type": "PValueUncorrected", 
+        "prov:value": {
+          "@type": "xsd:float", 
+          "@value": "1.0"
+        }, 
+        "label": "Extent Threshold"
+      }
+    ], 
     "CoordinateSpace": [
       {
         "voxelUnits": "[ \"mm\", \"mm\", \"mm\" ]", 
@@ -288,7 +299,7 @@
         "@type": "xsd:dateTime", 
         "@value": "2014-05-19T10:30:00+01:00"
       }, 
-      "@id": "_:ff27e25dcc16e40d5bdd50745430b0190b1", 
+      "@id": "_:f7160efa823194cb993e7d9e32961fb3fb1", 
       "prov:activity": {
         "@id": "niiri:export_id"
       }
@@ -327,6 +338,12 @@
       }, 
       {
         "crypto:sha512": "e43b6e01b0463fe7d40782137867a...", 
+        "fileName": "spmT_0001.hdr", 
+        "@id": "niiri:statistic_original_map_header_id", 
+        "format": "image/nifti"
+      }, 
+      {
+        "crypto:sha512": "e43b6e01b0463fe7d40782137867a...", 
         "fileName": "beta_0002.hdr", 
         "@id": "niiri:original_pe_map_header_2_id", 
         "format": "image/nifti"
@@ -345,12 +362,6 @@
       }, 
       {
         "crypto:sha512": "e43b6e01b0463fe7d40782137867a...", 
-        "fileName": "spmT_0001.hdr", 
-        "@id": "niiri:statistic_original_map_header_id", 
-        "format": "image/nifti"
-      }, 
-      {
-        "crypto:sha512": "e43b6e01b0463fe7d40782137867a...", 
         "fileName": "con_0001.hdr", 
         "@id": "niiri:original_contrast_map_header_id", 
         "format": "image/nifti"
@@ -359,21 +370,39 @@
     "Peak": [
       {
         "prov:wasDerivedFrom": {
-          "@id": "niiri:supra_threshold_cluster_0001"
+          "@id": "niiri:supra_threshold_cluster_0003"
         }, 
-        "pValueFWER": "1.82057147136e-10", 
-        "equivalentZStatistic": "7.80404869241", 
-        "pValueUncorrected": "2.99760216649e-15", 
-        "qValueFDR": "9.95383070868e-08", 
+        "pValueFWER": "4.05099727463e-06", 
+        "equivalentZStatistic": "6.43494304364", 
+        "pValueUncorrected": "6.17598194808e-11", 
+        "qValueFDR": "0.00046313051786", 
         "prov:value": {
           "@type": "xsd:float", 
-          "@value": "9.82185649872"
+          "@value": "7.49709033966"
         }, 
-        "label": "Peak 0003", 
+        "label": "Peak 0007", 
         "atLocation": {
-          "@id": "niiri:coordinate_0003"
+          "@id": "niiri:coordinate_0007"
         }, 
-        "@id": "niiri:peak_0003"
+        "@id": "niiri:peak_0007"
+      }, 
+      {
+        "prov:wasDerivedFrom": {
+          "@id": "niiri:supra_threshold_cluster_0001"
+        }, 
+        "pValueFWER": "0.0", 
+        "equivalentZStatistic": "inf", 
+        "pValueUncorrected": "4.4408920985e-16", 
+        "qValueFDR": "6.3705194445e-11", 
+        "prov:value": {
+          "@type": "xsd:float", 
+          "@value": "13.9346199036"
+        }, 
+        "label": "Peak 0001", 
+        "atLocation": {
+          "@id": "niiri:coordinate_0001"
+        }, 
+        "@id": "niiri:peak_0001"
       }, 
       {
         "prov:wasDerivedFrom": {
@@ -449,39 +478,21 @@
       }, 
       {
         "prov:wasDerivedFrom": {
-          "@id": "niiri:supra_threshold_cluster_0003"
-        }, 
-        "pValueFWER": "4.05099727463e-06", 
-        "equivalentZStatistic": "6.43494304364", 
-        "pValueUncorrected": "6.17598194808e-11", 
-        "qValueFDR": "0.00046313051786", 
-        "prov:value": {
-          "@type": "xsd:float", 
-          "@value": "7.49709033966"
-        }, 
-        "label": "Peak 0007", 
-        "atLocation": {
-          "@id": "niiri:coordinate_0007"
-        }, 
-        "@id": "niiri:peak_0007"
-      }, 
-      {
-        "prov:wasDerivedFrom": {
           "@id": "niiri:supra_threshold_cluster_0001"
         }, 
-        "pValueFWER": "0.0", 
-        "equivalentZStatistic": "inf", 
-        "pValueUncorrected": "4.4408920985e-16", 
-        "qValueFDR": "6.3705194445e-11", 
+        "pValueFWER": "1.82057147136e-10", 
+        "equivalentZStatistic": "7.80404869241", 
+        "pValueUncorrected": "2.99760216649e-15", 
+        "qValueFDR": "9.95383070868e-08", 
         "prov:value": {
           "@type": "xsd:float", 
-          "@value": "13.9346199036"
+          "@value": "9.82185649872"
         }, 
-        "label": "Peak 0001", 
+        "label": "Peak 0003", 
         "atLocation": {
-          "@id": "niiri:coordinate_0001"
+          "@id": "niiri:coordinate_0003"
         }, 
-        "@id": "niiri:peak_0001"
+        "@id": "niiri:peak_0003"
       }
     ], 
     "DisplayMaskMap": {
@@ -504,10 +515,10 @@
       }, 
       "prov:used": [
         {
-          "@id": "niiri:design_matrix_id"
+          "@id": "niiri:beta_map_id_2"
         }, 
         {
-          "@id": "niiri:contrast_id"
+          "@id": "niiri:design_matrix_id"
         }, 
         {
           "@id": "niiri:mask_id_2"
@@ -519,7 +530,7 @@
           "@id": "niiri:residual_mean_squares_map_id"
         }, 
         {
-          "@id": "niiri:beta_map_id_2"
+          "@id": "niiri:contrast_id"
         }
       ], 
       "@id": "niiri:contrast_estimation_id", 
@@ -547,19 +558,25 @@
       }, 
       "prov:wasAttributedTo": [
         {
-          "@id": "niiri:group_id"
+          "@id": "niiri:group2_id"
         }, 
         {
           "@id": "niiri:mr_scanner_id"
         }, 
         {
-          "@id": "niiri:group2_id"
+          "@id": "niiri:group_id"
         }
       ], 
       "targetIntensity": "100.0", 
       "grandMeanScaling": true, 
       "label": "Data", 
       "@id": "niiri:data_id"
+    }, 
+    "SPM": {
+      "softwareVersion": "12b.5853", 
+      "@id": "niiri:software_id", 
+      "@type": "prov:SoftwareAgent", 
+      "label": "SPM"
     }, 
     "ReselsPerVoxelMap": [
       {
@@ -607,16 +624,16 @@
     "ModelParameterEstimation": {
       "prov:used": [
         {
-          "@id": "niiri:design_matrix_id"
-        }, 
-        {
           "@id": "niiri:mask_id_1"
         }, 
         {
-          "@id": "niiri:data_id"
+          "@id": "niiri:design_matrix_id"
         }, 
         {
           "@id": "niiri:error_model_id"
+        }, 
+        {
+          "@id": "niiri:data_id"
         }
       ], 
       "prov:wasAssociatedWith": {
@@ -677,7 +694,7 @@
     ], 
     "NIDMResults": {
       "prov:qualifiedGeneration": {
-        "@id": "_:ff27e25dcc16e40d5bdd50745430b0190b1"
+        "@id": "_:f7160efa823194cb993e7d9e32961fb3fb1"
       }, 
       "version": "1.3.0", 
       "@id": "niiri:spm_results_id", 
@@ -693,11 +710,6 @@
         "label": "Coordinate: 0007", 
         "@id": "niiri:coordinate_0007", 
         "coordinateVector": "[ 36, -31, -14 ]"
-      }, 
-      {
-        "label": "Coordinate: 0004", 
-        "@id": "niiri:coordinate_0004", 
-        "coordinateVector": "[ 57, -22, 13 ]"
       }, 
       {
         "label": "Coordinate: 0005", 
@@ -718,6 +730,11 @@
         "label": "Coordinate: 0001", 
         "@id": "niiri:coordinate_0001", 
         "coordinateVector": "[ -60, -28, 13 ]"
+      }, 
+      {
+        "label": "Coordinate: 0004", 
+        "@id": "niiri:coordinate_0004", 
+        "coordinateVector": "[ 57, -22, 13 ]"
       }
     ], 
     "ResidualMeanSquaresMap": {
@@ -739,15 +756,6 @@
     }, 
     "ContrastMap": [
       {
-        "format": "image/nifti", 
-        "hasMapHeader": {
-          "@id": "niiri:original_contrast_map_header_id"
-        }, 
-        "fileName": "con_0001.img", 
-        "crypto:sha512": "e43b6e01b0463fe7d40782137867a", 
-        "@id": "niiri:contrast_map_id_der"
-      }, 
-      {
         "prov:wasDerivedFrom": {
           "@id": "niiri:contrast_map_id_der"
         }, 
@@ -767,19 +775,19 @@
         "crypto:sha512": "e43b6e01b0463fe7d40782137867a", 
         "fileName": "Contrast.nii.gz", 
         "@id": "niiri:contrast_map_id"
+      }, 
+      {
+        "format": "image/nifti", 
+        "hasMapHeader": {
+          "@id": "niiri:original_contrast_map_header_id"
+        }, 
+        "fileName": "con_0001.img", 
+        "crypto:sha512": "e43b6e01b0463fe7d40782137867a", 
+        "@id": "niiri:contrast_map_id_der"
       }
     ], 
     "Inference": {
       "prov:used": [
-        {
-          "@id": "niiri:peak_definition_criteria_id"
-        }, 
-        {
-          "@id": "niiri:extent_threshold_id"
-        }, 
-        {
-          "@id": "niiri:mask_id_2"
-        }, 
         {
           "@id": "niiri:cluster_definition_criteria_id"
         }, 
@@ -787,13 +795,22 @@
           "@id": "niiri:resels_per_voxel_map_id"
         }, 
         {
-          "@id": "niiri:mask_id_3"
+          "@id": "niiri:mask_id_2"
+        }, 
+        {
+          "@id": "niiri:statistic_map_id"
+        }, 
+        {
+          "@id": "niiri:peak_definition_criteria_id"
         }, 
         {
           "@id": "niiri:height_threshold_id"
         }, 
         {
-          "@id": "niiri:statistic_map_id"
+          "@id": "niiri:mask_id_3"
+        }, 
+        {
+          "@id": "niiri:extent_threshold_id"
         }
       ], 
       "prov:wasAssociatedWith": {
@@ -873,32 +890,15 @@
       "label": "Contrast Standard Error Map", 
       "@id": "niiri:contrast_standard_error_map_id"
     }, 
-    "Statistic": [
-      {
-        "equivalentThreshold": [
-          {
-            "@id": "niiri:height_threshold_id_2"
-          }, 
-          {
-            "@id": "niiri:height_threshold_id_3"
-          }
-        ], 
-        "clusterSizeInVoxels": "0", 
-        "label": "Extent Threshold: k>=0", 
-        "clusterSizeInResels": "0.0", 
-        "@id": "niiri:extent_threshold_id", 
-        "@type": "ExtentThreshold"
+    "Statistic": {
+      "@id": "niiri:height_threshold_id_2", 
+      "@type": "HeightThreshold", 
+      "prov:value": {
+        "@type": "xsd:float", 
+        "@value": "5.23529984739"
       }, 
-      {
-        "@id": "niiri:height_threshold_id_2", 
-        "@type": "HeightThreshold", 
-        "prov:value": {
-          "@type": "xsd:float", 
-          "@value": "5.23529984739"
-        }, 
-        "label": "Height Threshold: p<5.23529984739211"
-      }
-    ], 
+      "label": "Height Threshold: p<5.23529984739211"
+    }, 
     "ClusterDefinitionCriteria": {
       "@id": "niiri:cluster_definition_criteria_id", 
       "hasConnectivityCriterion": {

--- a/nidm/nidm-results/test/ground_truth/display_mask/nidm.json
+++ b/nidm/nidm-results/test/ground_truth/display_mask/nidm.json
@@ -1,5 +1,5 @@
 {
-  "@context": "http://purl.org/nidash/context", 
+  "@context": "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/nidmr.json", 
   "@id": "file:///home/karl/Work/INCF/nidm/nidm/nidm/nidm-results/test/ground_truth/display_mask/nidm.ttl", 
   "records": {
     "Inference": {

--- a/nidm/nidm-results/test/ground_truth/event_related_design/nidm.json
+++ b/nidm/nidm-results/test/ground_truth/event_related_design/nidm.json
@@ -1,5 +1,5 @@
 {
-  "@context": "http://purl.org/nidash/context", 
+  "@context": "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/nidmr.json", 
   "@id": "file:///home/karl/Work/INCF/nidm/nidm/nidm/nidm-results/test/ground_truth/event_related_design/nidm.ttl", 
   "records": {
     "ModelParameterEstimation": {

--- a/nidm/nidm-results/test/ground_truth/explicit_mask/nidm.json
+++ b/nidm/nidm-results/test/ground_truth/explicit_mask/nidm.json
@@ -1,5 +1,5 @@
 {
-  "@context": "http://purl.org/nidash/context", 
+  "@context": "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/nidmr.json", 
   "@id": "file:///home/karl/Work/INCF/nidm/nidm/nidm/nidm-results/test/ground_truth/explicit_mask/nidm.ttl", 
   "records": {
     "ModelParameterEstimation": {

--- a/nidm/nidm-results/test/ground_truth/f_test/nidm.json
+++ b/nidm/nidm-results/test/ground_truth/f_test/nidm.json
@@ -1,7 +1,11 @@
 {
-  "@context": "http://purl.org/nidash/context", 
+  "@context": "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/nidmr.json", 
   "@id": "file:///home/karl/Work/INCF/nidm/nidm/nidm/nidm-results/test/ground_truth/f_test/nidm.ttl", 
   "records": {
+    "ContrastEstimation": {
+      "@id": "niiri:contrast_estimation_id", 
+      "@type": "prov:Activity"
+    }, 
     "ContrastExplainedMeanSquareMap": {
       "prov:wasGeneratedBy": {
         "@id": "niiri:contrast_estimation_id"
@@ -10,10 +14,6 @@
       "label": "Contrast Explained Mean Square Map", 
       "fileName": "ContrastExplainedMeanSquareMap_F001.nii.gz", 
       "@id": "niiri:contrast_explained_mean_square_map_id"
-    }, 
-    "prov:Activity": {
-      "@id": "niiri:contrast_estimation_id", 
-      "@type": "ContrastEstimation"
     }
   }
 }

--- a/nidm/nidm-results/test/ground_truth/voxelwise_p001_unc/nidm.json
+++ b/nidm/nidm-results/test/ground_truth/voxelwise_p001_unc/nidm.json
@@ -1,5 +1,5 @@
 {
-  "@context": "http://purl.org/nidash/context", 
+  "@context": "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/nidmr.json", 
   "@id": "file:///home/karl/Work/INCF/nidm/nidm/nidm/nidm-results/test/ground_truth/voxelwise_p001_unc/nidm.ttl", 
   "records": {
     "Inference": {

--- a/nidm/nidm-results/test/ground_truth/voxelwise_p050_fwe/nidm.json
+++ b/nidm/nidm-results/test/ground_truth/voxelwise_p050_fwe/nidm.json
@@ -1,14 +1,14 @@
 {
-  "@context": "http://purl.org/nidash/context", 
+  "@context": "https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/nidmr.json", 
   "@id": "file:///home/karl/Work/INCF/nidm/nidm/nidm/nidm-results/test/ground_truth/voxelwise_p050_fwe/nidm.ttl", 
   "records": {
     "Inference": {
       "prov:used": [
         {
-          "@id": "niiri:height_threshold_id"
+          "@id": "niiri:extent_threshold_id"
         }, 
         {
-          "@id": "niiri:extent_threshold_id"
+          "@id": "niiri:height_threshold_id"
         }
       ], 
       "@id": "niiri:inference_id"

--- a/scripts/refresh.py
+++ b/scripts/refresh.py
@@ -32,14 +32,14 @@ import nidm_html
 def main():
     # --- NIDM-Experiment
     # Update terms README
-    UpdateExpTermReadme.main()
+    #UpdateExpTermReadme.main()
     # --- NIDM-Results
     # Create a JSON-LD context for NIDM-Results
     create_nidmr_context.main()
     # Re-create turtle examples from template
-    recompute_all_ex.main()
+    #recompute_all_ex.main()
     # Convert turtle to provn and upload to Prov Store
-    UpdateExampleReadmes.main()
+    #UpdateExampleReadmes.main()
     # Update terms README
     UpdateTermReadme.main()
     # Update specifications


### PR DESCRIPTION
Issue is with trying to reach the nidm-results context file 
https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-results/terms/nidmr.json
with purl redirect:
http://purl.org/nidash/context
error message discuss in [issue 148](https://github.com/incf-nidash/nidm-specs/issues/418)
Problem can't be solved without upgrading urllib3/requests to versions past what's installed with nidmresults package.
To resolve, I commented out two lines in refresh.py that called the json-ld context file.